### PR TITLE
Do not typeset the same documents twice

### DIFF
--- a/l3build.lua
+++ b/l3build.lua
@@ -2064,25 +2064,30 @@ function doc(files)
   depinstall(typesetdeps)
   unpack({sourcefiles, typesetsourcefiles})
   -- Main loop for doc creation
+  local done = {}
   for _, typesetfiles in ipairs({typesetdemofiles, typesetfiles}) do
     for _,i in ipairs(typesetfiles) do
       for _, dir in ipairs({unpackdir, typesetdir}) do
         for j,_ in pairs(tree(dir, i)) do
-          -- Allow for command line selection of files
-          local typeset = true
-          if files and next(files) then
-            typeset = false
-            for _,k in ipairs(files) do
-              if k == jobname(j) then
-                typeset = true
-                break
+          if not done[j] then
+            -- Allow for command line selection of files
+            local typeset = true
+            if files and next(files) then
+              typeset = false
+              for _,k in ipairs(files) do
+                if k == jobname(j) then
+                  typeset = true
+                  break
+                end
               end
             end
-          end
-          if typeset then
-            local errorlevel = typesetpdf(j, dir)
-            if errorlevel ~= 0 then
-              return errorlevel
+            if typeset then
+              local errorlevel = typesetpdf(j, dir)
+              if errorlevel ~= 0 then
+                return errorlevel
+              else
+                done[j] = true
+              end
             end
           end
         end


### PR DESCRIPTION
The `doc` function searches for the `typesetfiles` and `typesetdemofiles` in both `unpackdir` and `typesetdir`. When a file shows up in both, because it was matched by both `sourcefiles` and `unpackfiles` or copied from `unpackdir` to `typesetdir`, the same file is processed twice from both locations. As the same file leads to the same PDF output, this unnecessarily wastes time running TeX and can be saved.