### PR TITLE
Use the basename function instead of its contents

### DIFF
--- a/l3build.lua
+++ b/l3build.lua
@@ -1586,7 +1586,7 @@ end
 
 -- Strip the extension from a file name (if present)
 function jobname(file)
-  local name = match(select(2, splitpath(file)), "^(.*)%.")
+  local name = match(basename(file), "^(.*)%.")
   return name or file
 end
 


### PR DESCRIPTION
This just eliminates a small code duplication. Most probably it was overlooked while applying pull requests that changed code in the same vicinity.