### PR TITLE
Accessing files in subdirectories

### DIFF
--- a/l3build.lua
+++ b/l3build.lua
@@ -1694,7 +1694,7 @@ end
 
 function typesetpdf(file, dir)
   local name = jobname(file)
-  print("Typesetting " .. name)
+  print("Typesetting " .. gsub(file, "%.[^.]+$", ""))
   local errorlevel = typeset(file, dir)
   if errorlevel == 0 then
     os_remove(name .. ".pdf")

--- a/l3build.lua
+++ b/l3build.lua
@@ -2077,7 +2077,7 @@ function doc(files)
             if files and next(files) then
               typeset = false
               for _,k in ipairs(files) do
-                if k == gsub(j, "%.[^.]+$", "") then
+                if k == gsub(j, "^%./(.*)%.[^.]+$", "%1") then
                   typeset = true
                   break
                 end

--- a/l3build.lua
+++ b/l3build.lua
@@ -1698,7 +1698,7 @@ function typesetpdf(file, dir)
   local errorlevel = typeset(file, dir)
   if errorlevel == 0 then
     os_remove(name .. ".pdf")
-    cp(name .. ".pdf", typesetdir, ".")
+    cp(gsub(file, "%.[^.]+$", ".pdf"), typesetdir, ".")
   else
     print(" ! Compilation failed")
   end

--- a/l3build.lua
+++ b/l3build.lua
@@ -1694,7 +1694,7 @@ end
 
 function typesetpdf(file, dir)
   local name = gsub(file, "%.[^.]+$", "")
-  print("Typesetting " .. gsub(name, "^%./", ""))
+  print("Typesetting " .. name)
   local errorlevel = typeset(file, dir)
   if errorlevel == 0 then
     name = name .. ".pdf"
@@ -2072,12 +2072,13 @@ function doc(files)
       for _, dir in ipairs({unpackdir, typesetdir}) do
         for j,_ in pairs(tree(dir, i)) do
           if not done[j] then
+            j = gsub(j, "^%./", "")
             -- Allow for command line selection of files
             local typeset = true
             if files and next(files) then
               typeset = false
               for _,k in ipairs(files) do
-                if k == gsub(j, "^%./(.*)%.[^.]+$", "%1") then
+                if k == gsub(j, "%.[^.]+$", "") then
                   typeset = true
                   break
                 end

--- a/l3build.lua
+++ b/l3build.lua
@@ -1693,12 +1693,12 @@ function tex(file, dir)
 end
 
 function typesetpdf(file, dir)
-  local name = jobname(file)
-  print("Typesetting " .. gsub(file, "%.[^.]+$", ""))
+  local name = gsub(file, "%.[^.]+$", "")
+  print("Typesetting " .. name)
   local errorlevel = typeset(file, dir)
   if errorlevel == 0 then
-    os_remove(name .. ".pdf")
-    cp(gsub(file, "%.[^.]+$", ".pdf"), typesetdir, ".")
+    os_remove(jobname(name) .. ".pdf")
+    cp(name .. ".pdf", typesetdir, ".")
   else
     print(" ! Compilation failed")
   end

--- a/l3build.lua
+++ b/l3build.lua
@@ -1697,8 +1697,9 @@ function typesetpdf(file, dir)
   print("Typesetting " .. name)
   local errorlevel = typeset(file, dir)
   if errorlevel == 0 then
-    os_remove(jobname(name) .. ".pdf")
-    cp(name .. ".pdf", typesetdir, ".")
+    name = name .. ".pdf"
+    os_remove(jobname(name))
+    cp(name, typesetdir, ".")
   else
     print(" ! Compilation failed")
   end

--- a/l3build.lua
+++ b/l3build.lua
@@ -1694,7 +1694,7 @@ end
 
 function typesetpdf(file, dir)
   local name = gsub(file, "%.[^.]+$", "")
-  print("Typesetting " .. name)
+  print("Typesetting " .. gsub(name, "^%./", ""))
   local errorlevel = typeset(file, dir)
   if errorlevel == 0 then
     name = name .. ".pdf"

--- a/l3build.lua
+++ b/l3build.lua
@@ -2077,7 +2077,7 @@ function doc(files)
             if files and next(files) then
               typeset = false
               for _,k in ipairs(files) do
-                if k == jobname(j) then
+                if k == gsub(j, "%.[^.]+$", "") then
                   typeset = true
                   break
                 end


### PR DESCRIPTION
This adjusts the following two related routines to correctly deal with files in subdirectories.
- copying out typeset files from the `build` directory to the project root
- filtering which files to typeset using command-line-arguments