### PR TITLE
resolve copied links

### DIFF
--- a/l3build.lua
+++ b/l3build.lua
@@ -611,7 +611,7 @@ function cp(glob, source, dest)
         )
       end
     else
-      errorlevel = execute("cp -rf " .. source .. " " .. dest)
+      errorlevel = execute("cp -rLf " .. source .. " " .. dest)
     end
     if errorlevel ~=0 then
       return errorlevel


### PR DESCRIPTION
When any file copied into a build directory is a symbolic link, the link could not correctly point to its target from its new location, should the target not coincidentally be copied as well. Errors of the kind "file not found" will then occur for the copied links.  This is true for targets inside as well as outside of the project, as long as they are specified relatively.

Resolving the links, copying the file content of the target instead of the link, eliminates this problem.

I did not test this under Windows, but as far as I can tell from [the documentation of the xcopy utility](https://technet.microsoft.com/de-de/library/cc771254(v=ws.10).aspx), specifically the description of the `/b` option, this was the default behavior there all along.