### PR TITLE
Allow the "error level" to be recorded in TLG files

### DIFF
--- a/l3build.dtx
+++ b/l3build.dtx
@@ -148,6 +148,7 @@
 \luavarset{scriptname}  {"build.lua"} {Name of script used in dependencies.}
 \luavarset{typesetcmds} {""}          {Instructions to be passed to \TeX{} when doing typesetting.}
 \luavarset{versionform} {""}          {Nature of version strings for auto-replacement.}
+\luavarset{recorderrorlevel} {false}  {Include error level(s) from test run(s) in TLG files?}
 }
 \allluavars
 \newcommand\luavartypeset{%
@@ -475,6 +476,12 @@
 %
 % If the \texttt{--engine} (or \texttt{-e}) is specified (one of |pdftex|, |xetex|, or |luatex|), the saved output is stored in \texttt{\meta{name}.\meta{engine}.tlg}. This is necessary if running the test through a different engine produces a different output.
 % A normalisation process is performed when checking to avoid common differences such as register allocation; full details are listed in section~\ref{sec:norm}.
+%
+% If the \var{recorderrorlevel} variable is set \var{true}, additional information
+% will be added to the \texttt{.tlg} to record the \enquote{output level} of the
+% typesetting compilation of the \texttt{.lvt} file. If the typesetting compilation
+% completed without throwing an error (due to \TeX\ programming errors, for example),
+% the \enquote{output level} is zero, else non-zero.
 % \end{buildcmd}
 %
 % \begin{buildcmd}{save -p \meta{name(s)}}

--- a/l3build.dtx
+++ b/l3build.dtx
@@ -148,7 +148,7 @@
 \luavarset{scriptname}  {"build.lua"} {Name of script used in dependencies.}
 \luavarset{typesetcmds} {""}          {Instructions to be passed to \TeX{} when doing typesetting.}
 \luavarset{versionform} {""}          {Nature of version strings for auto-replacement.}
-\luavarset{recorderrorlevel} {false}  {Include error level(s) from test run(s) in TLG files?}
+\luavarset{recordstatus} {false}      {Include error level(s) from test run(s) in TLG files?}
 }
 \allluavars
 \newcommand\luavartypeset{%
@@ -477,11 +477,11 @@
 % If the \texttt{--engine} (or \texttt{-e}) is specified (one of |pdftex|, |xetex|, or |luatex|), the saved output is stored in \texttt{\meta{name}.\meta{engine}.tlg}. This is necessary if running the test through a different engine produces a different output.
 % A normalisation process is performed when checking to avoid common differences such as register allocation; full details are listed in section~\ref{sec:norm}.
 %
-% If the \var{recorderrorlevel} variable is set \var{true}, additional information
-% will be added to the \texttt{.tlg} to record the \enquote{output level} of the
+% If the \var{recordstatus} variable is set \var{true}, additional information
+% will be added to the \texttt{.tlg} to record the \enquote{exit status} of the
 % typesetting compilation of the \texttt{.lvt} file. If the typesetting compilation
 % completed without throwing an error (due to \TeX\ programming errors, for example),
-% the \enquote{output level} is zero, else non-zero.
+% the \enquote{exit status} is zero, else non-zero.
 % \end{buildcmd}
 %
 % \begin{buildcmd}{save -p \meta{name(s)}}

--- a/l3build.dtx
+++ b/l3build.dtx
@@ -1463,6 +1463,7 @@
 }
 \let\TYPE\LONGTYPEOUT
 %    \end{macrocode}
+% \end{macro}
 %
 % \begin{macro}{\STARTMESSAGE, \START}
 %   Start the test, after the optional |\documentclass|

--- a/l3build.lua
+++ b/l3build.lua
@@ -177,7 +177,7 @@ packtdszip   = packtdszip   or false
 scriptname   = scriptname   or "build.lua"
 typesetcmds  = typesetcmds  or ""
 versionform  = versionform  or ""
-recorderrorlevel = recorderrorlevel or false
+recordstatus = recordstatus or false
 
 -- Extensions for various file types: used to abstract out stuff a bit
 bakext = bakext or ".bak"
@@ -1067,14 +1067,10 @@ local function formatlog(logfile, newfile, engine, errlevels)
   local newfile = open(newfile, "w")
   output(newfile)
   write(newlog)
-  if recorderrorlevel then
+  if recordstatus then
     write('***************\n')
     for i = 1, checkruns do
-      if errlevels[i] == 0 then
-        write('Run ' .. i .. ' executed without error')
-      else
-        write('Run ' .. i .. ' executed with error level ' .. errlevels[i] )
-      end
+      write('Compilation ' .. i .. ' of test file completed with exit status ' .. errlevels[i] )
     end
   end
   close(newfile)


### PR DESCRIPTION
When testing a package, it's good to be able to check whether a TeX error has been tripped even if it's not caught inside \TIMO..\OMIT. This code keeps track of the error levels from each typesetting run and simply appends them to the TLG file if a conditional ("recorderrorlevel") is set true.

It might also make sense to include the status from bibtex compilations etc but I needed to keep things simple for the time being... 

Happy to discuss naming. Not sure if "error level" is canonical. Could also use "exit status". I think getting the text right here (that's appended to the TLG) is also important before it's rolled out, and not sure if what I've written is best...