### PR TITLE
Add a sourcefiledir variable

### DIFF
--- a/l3build.dtx
+++ b/l3build.dtx
@@ -58,7 +58,8 @@
 \luavarset{exclmodules}{\{~\}}{Directories to be excluded from automatic module detection}
 \luavarseparator
 \luavarset{maindir}     {"."}{The top level directory for this module or bundle.}
-\luavarset{docfiledir}        {maindir}{Where to look for files for the documentation tree.}
+\luavarset{sourcefiledir}{maindir}{Where to look for the source files.}
+\luavarset{docfiledir}  {maindir}{Where to look for files for the documentation tree.}
 \luavarset{supportdir}  {maindir .. "/support"}     {Where copies of files to support check/doc compilation are stored.}
 \luavarset{testfiledir} {maindir .. "/testfiles"}   {Where the tests are.}
 \luavarset{testsuppdir} {testfiledir .. "/support"} {Where support files for the tests are.}

--- a/l3build.lua
+++ b/l3build.lua
@@ -2333,7 +2333,7 @@ bundleunpack = bundleunpack or function(sourcedirs, sources)
   if errorlevel ~=0 then
     return errorlevel
   end
-  for _,i in ipairs(sourcedirs or {"."}) do
+  for _,i in ipairs(sourcedirs or {sourcefiledir}) do
     for _,j in ipairs(sources or {sourcefiles}) do
       for _,k in ipairs(j) do
         errorlevel = cp(k, i, unpackdir)

--- a/l3build.lua
+++ b/l3build.lua
@@ -64,11 +64,11 @@ end
 maindir = maindir or "."
 
 -- Substructure files
-docfiledir  = docfiledir  or maindir
+docfiledir    = docfiledir    or maindir
 sourcefiledir = sourcefiledir or maindir
-supportdir  = supportdir  or maindir     .. "/support"
-testfiledir = testfiledir or maindir     .. "/testfiles"
-testsuppdir = testsuppdir or testfiledir .. "/support"
+supportdir    = supportdir    or maindir     .. "/support"
+testfiledir   = testfiledir   or maindir     .. "/testfiles"
+testsuppdir   = testsuppdir   or testfiledir .. "/support"
 
 -- Structure within a development area
 builddir   = builddir   or maindir .. "/build"

--- a/l3build.lua
+++ b/l3build.lua
@@ -65,6 +65,7 @@ maindir = maindir or "."
 
 -- Substructure files
 docfiledir  = docfiledir  or maindir
+sourcefiledir = sourcefiledir or maindir
 supportdir  = supportdir  or maindir     .. "/support"
 testfiledir = testfiledir or maindir     .. "/testfiles"
 testsuppdir = testsuppdir or testfiledir .. "/support"

--- a/l3build.lua
+++ b/l3build.lua
@@ -872,10 +872,11 @@ function copyctan()
       cp(file, docfiledir, ctandir .. "/" .. ctanpkg)
     end
   end
-  for _,filetype in pairs({sourcefiles, textfiles}) do
-    for _,file in pairs(filetype) do
-      cp(file, maindir, ctandir .. "/" .. ctanpkg)
-    end
+  for _,file in pairs(sourcefiles) do
+    cp(file, sourcefiledir, ctandir .. "/" .. ctanpkg)
+  end
+  for _,file in pairs(textfiles) do
+    cp(file, maindir, ctandir .. "/" .. ctanpkg)
   end
 end
 
@@ -921,7 +922,7 @@ function copytds()
   )
   install(unpackdir, "makeindex", {makeindexfiles}, true)
   install(unpackdir, "bibtex/bst", {bstfiles}, true)
-  install(maindir, "source", {sourcelist})
+  install(sourcefiledir, "source", {sourcelist})
   install(unpackdir, "tex", {installfiles})
 end
 
@@ -1924,7 +1925,7 @@ function cmdcheck()
     end
   end
   for _,file in pairs(sourcefiles) do
-    cp(file, maindir, typesetdir)
+    cp(file, sourcefiledir, typesetdir)
   end
   local engine = gsub(stdengine, "tex$", "latex")
   local localdir = abspath(localdir)
@@ -2086,13 +2087,13 @@ function doc(files)
     end
   end
   for _,file in pairs(sourcefiles) do
-    cp(file, maindir, typesetdir)
+    cp(file, sourcefiledir, typesetdir)
   end
   for _,i in ipairs(typesetsuppfiles) do
     cp(i, supportdir, typesetdir)
   end
   depinstall(typesetdeps)
-  unpack({sourcefiles, typesetsourcefiles}, {maindir, docfiledir})
+  unpack({sourcefiles, typesetsourcefiles}, {sourcefiledir, docfiledir})
   -- Main loop for doc creation
   local done = {}
   for _, typesetfiles in ipairs({typesetdemofiles, typesetfiles}) do


### PR DESCRIPTION
This will allow structures such as that used by `beamer`, where sources and docs are separate. That is particularly useful for material *not* in `.dtx` format, where they may be significant 'structure' to the source.