### PR TITLE
Revert "Add a sourcefiledir variable"

### DIFF
--- a/l3build.dtx
+++ b/l3build.dtx
@@ -58,8 +58,7 @@
 \luavarset{exclmodules}{\{~\}}{Directories to be excluded from automatic module detection}
 \luavarseparator
 \luavarset{maindir}     {"."}{The top level directory for this module or bundle.}
-\luavarset{sourcefiledir}{maindir}{Where to look for the source files.}
-\luavarset{docfiledir}  {maindir}{Where to look for files for the documentation tree.}
+\luavarset{docfiledir}        {maindir}{Where to look for files for the documentation tree.}
 \luavarset{supportdir}  {maindir .. "/support"}     {Where copies of files to support check/doc compilation are stored.}
 \luavarset{testfiledir} {maindir .. "/testfiles"}   {Where the tests are.}
 \luavarset{testsuppdir} {testfiledir .. "/support"} {Where support files for the tests are.}

--- a/l3build.lua
+++ b/l3build.lua
@@ -65,7 +65,6 @@ maindir = maindir or "."
 
 -- Substructure files
 docfiledir  = docfiledir  or maindir
-sourcefiledir = sourcefiledir or maindir
 supportdir  = supportdir  or maindir     .. "/support"
 testfiledir = testfiledir or maindir     .. "/testfiles"
 testsuppdir = testsuppdir or testfiledir .. "/support"

--- a/l3build.lua
+++ b/l3build.lua
@@ -2333,7 +2333,7 @@ bundleunpack = bundleunpack or function(sourcedirs, sources)
   if errorlevel ~=0 then
     return errorlevel
   end
-  for _,i in ipairs(sourcedirs or {sourcefiledir}) do
+  for _,i in ipairs(sourcedirs or {"."}) do
     for _,j in ipairs(sources or {sourcefiles}) do
       for _,k in ipairs(j) do
         errorlevel = cp(k, i, unpackdir)

--- a/l3build.lua
+++ b/l3build.lua
@@ -872,11 +872,10 @@ function copyctan()
       cp(file, docfiledir, ctandir .. "/" .. ctanpkg)
     end
   end
-  for _,file in pairs(sourcefiles) do
-    cp(file, sourcefiledir, ctandir .. "/" .. ctanpkg)
-  end
-  for _,file in pairs(textfiles) do
-    cp(file, maindir, ctandir .. "/" .. ctanpkg)
+  for _,filetype in pairs({sourcefiles, textfiles}) do
+    for _,file in pairs(filetype) do
+      cp(file, maindir, ctandir .. "/" .. ctanpkg)
+    end
   end
 end
 
@@ -922,7 +921,7 @@ function copytds()
   )
   install(unpackdir, "makeindex", {makeindexfiles}, true)
   install(unpackdir, "bibtex/bst", {bstfiles}, true)
-  install(sourcefiledir, "source", {sourcelist})
+  install(maindir, "source", {sourcelist})
   install(unpackdir, "tex", {installfiles})
 end
 
@@ -1925,7 +1924,7 @@ function cmdcheck()
     end
   end
   for _,file in pairs(sourcefiles) do
-    cp(file, sourcefiledir, typesetdir)
+    cp(file, maindir, typesetdir)
   end
   local engine = gsub(stdengine, "tex$", "latex")
   local localdir = abspath(localdir)
@@ -2087,13 +2086,13 @@ function doc(files)
     end
   end
   for _,file in pairs(sourcefiles) do
-    cp(file, sourcefiledir, typesetdir)
+    cp(file, maindir, typesetdir)
   end
   for _,i in ipairs(typesetsuppfiles) do
     cp(i, supportdir, typesetdir)
   end
   depinstall(typesetdeps)
-  unpack({sourcefiles, typesetsourcefiles}, {sourcefiledir, docfiledir})
+  unpack({sourcefiles, typesetsourcefiles}, {maindir, docfiledir})
   -- Main loop for doc creation
   local done = {}
   for _, typesetfiles in ipairs({typesetdemofiles, typesetfiles}) do

--- a/l3build.lua
+++ b/l3build.lua
@@ -64,11 +64,11 @@ end
 maindir = maindir or "."
 
 -- Substructure files
-docfiledir    = docfiledir    or maindir
+docfiledir  = docfiledir  or maindir
 sourcefiledir = sourcefiledir or maindir
-supportdir    = supportdir    or maindir     .. "/support"
-testfiledir   = testfiledir   or maindir     .. "/testfiles"
-testsuppdir   = testsuppdir   or testfiledir .. "/support"
+supportdir  = supportdir  or maindir     .. "/support"
+testfiledir = testfiledir or maindir     .. "/testfiles"
+testsuppdir = testsuppdir or testfiledir .. "/support"
 
 -- Structure within a development area
 builddir   = builddir   or maindir .. "/build"

--- a/l3build.lua
+++ b/l3build.lua
@@ -838,7 +838,7 @@ function checkinit()
   for _,i in ipairs(filelist(localdir)) do
     cp(i, localdir, testdir)
   end
-  bundleunpack({sourcefiledir, testfiledir})
+  bundleunpack({".", testfiledir})
   for _,i in ipairs(installfiles) do
     cp(i, unpackdir, testdir)
   end
@@ -1895,9 +1895,7 @@ function clean()
     cleandir(typesetdir) +
     cleandir(unpackdir)
   for _,i in ipairs(cleanfiles) do
-    for _,dir in pairs({maindir, sourcefiledir, docfiledir}) do
-      errorlevel = rm(dir, i) + errorlevel
-    end
+    errorlevel = rm(".", i) + errorlevel
   end
   return errorlevel
 end
@@ -1905,7 +1903,7 @@ end
 function bundleclean()
   local errorlevel = call(modules, "clean")
   for _,i in ipairs(cleanfiles) do
-    errorlevel = rm(maindir, i) + errorlevel
+    errorlevel = rm(".", i) + errorlevel
   end
   return (
     errorlevel     +
@@ -1933,7 +1931,7 @@ function cmdcheck()
   local localdir = abspath(localdir)
   print("Checking source files")
   for _,i in ipairs(cmdchkfiles) do
-    for _,j in ipairs(filelist(sourcefiledir, i)) do
+    for _,j in ipairs(filelist(".", i)) do
       print("  " .. jobname(j))
       run(
         testdir,
@@ -2009,7 +2007,7 @@ function ctan(standalone)
   end
   if errorlevel == 0 then
     for _,i in ipairs(textfiles) do
-      for _,j in pairs({unpackdir, maindir}) do
+      for _,j in pairs({unpackdir, "."}) do
         cp(i, j, ctandir .. "/" .. ctanpkg)
         cp(i, j, tdsdir .. "/doc/" .. tdsroot .. "/" .. bundle)
       end
@@ -2019,7 +2017,7 @@ function ctan(standalone)
       cp(ctanpkg .. ".tds.zip", tdsdir, ctandir)
     end
     dirzip(ctandir, ctanpkg)
-    cp(ctanpkg .. ".zip", ctandir, maindir)
+    cp(ctanpkg .. ".zip", ctandir, ".")
   else
     print("\n====================")
     print("Typesetting failed, zip stage skipped!")
@@ -2031,20 +2029,20 @@ end
 function bundlectan()
   -- Generate a list of individual file names excluding those in the second
   -- argument: the latter is a table
-  local function excludelist(include, exclude, dir)
+  local function excludelist(include, exclude)
     local include = include or { }
     local exclude = exclude or { }
     local includelist = { }
     local excludelist = { }
     for _,i in ipairs(exclude) do
       for _,j in ipairs(i) do
-        for _,k in ipairs(filelist(dir, j)) do
+        for _,k in ipairs(filelist(".", j)) do
           excludelist[k] = true
         end
       end
     end
     for _,i in ipairs(include) do
-      for _,j in ipairs(filelist(dir, i)) do
+      for _,j in ipairs(filelist(".", i)) do
         if not excludelist[j] then
           insert(includelist, j)
         end
@@ -2066,9 +2064,9 @@ function bundlectan()
     for _,v in pairs(typesetdemofiles) do
       insert(typesetfiles, v)
     end
-    typesetlist = excludelist(typesetfiles, {sourcefiles}, docfiledir)
+    typesetlist = excludelist(typesetfiles, {sourcefiles})
     sourcelist = excludelist(
-      sourcefiles, {bstfiles, installfiles, makeindexfiles}, sourcefiledir
+      sourcefiles, {bstfiles, installfiles, makeindexfiles}
     )
     copyctan()
     copytds()
@@ -2293,7 +2291,7 @@ function setversion(dir)
   end
   local date = options["date"] or os_date("%Y-%m-%d")
   local version = options["version"] or -1
-  local dir = dir or sourcefiledir
+  local dir = dir or "."
   for _,i in pairs(versionfiles) do
     for _,j in pairs(filelist(dir, i)) do
       rewrite(dir, j, date, version)


### PR DESCRIPTION
Reverts latex3/l3build#36

There's an issue I'd not considered: the more complex issue of our bundle situation. That more-or-less does rely on a hard-coded `"."` as `maindir` is not necessarily fixed. There are at least a couple of solutions, but which is best will need some more thought.