### PR TITLE
Enable complex source layouts (fixes #2)

### DIFF
--- a/examples/Bundle-Flat/Module-One/build.lua
+++ b/examples/Bundle-Flat/Module-One/build.lua
@@ -1,0 +1,10 @@
+#!/usr/bin/env texlua
+
+bundle = "bundle-flat"
+module = "module-one"
+maindir = ".."
+
+typesetfiles  = {"*.tex"}
+
+kpse.set_program_name("kpsewhich")
+dofile(kpse.lookup("l3build.lua"))

--- a/examples/Bundle-Flat/Module-One/module-one-code.tex
+++ b/examples/Bundle-Flat/Module-One/module-one-code.tex
@@ -1,0 +1,3 @@
+
+\AtBeginDocument{\AlsoImplementation}
+\input{module-one.dtx}

--- a/examples/Bundle-Flat/Module-One/module-one.dtx
+++ b/examples/Bundle-Flat/Module-One/module-one.dtx
@@ -1,0 +1,50 @@
+%
+% \iffalse
+%<*driver>
+\ProvidesFile{module-one.dtx}
+%</driver>
+%<pkg>\ProvidesPackage{module-one}
+%<*pkg>
+  [2017/12/11 v0.1 Module One example]
+%</pkg>
+%<*driver>
+\documentclass{ltxdoc}
+\EnableCrossrefs
+\CodelineIndex
+\begin{document}
+  \DocInput{module-one.dtx}
+\end{document}
+%</driver>
+% \fi
+%
+% \GetFileInfo{module-one.dtx}
+% \title{The Module One example}
+% \date{\fileversion \qquad \filedate}
+% \maketitle
+%
+% \begin{abstract}
+% This is the documentation of the Module One example.
+% \end{abstract}
+%
+% \section{Introduction}
+%
+% This is where you would explain the package to a user.
+%
+% \StopEventually{}
+%
+% \section{Implementation}
+%
+%    \begin{macrocode}
+%<*pkg>
+%    \end{macrocode}
+%
+%    \begin{macrocode}
+\typeout{Actually this isn't a real package!}
+%    \end{macrocode}
+%
+%    \begin{macrocode}
+%</pkg>
+%    \end{macrocode}
+%
+% \Finale
+%

--- a/examples/Bundle-Flat/Module-One/module-one.ins
+++ b/examples/Bundle-Flat/Module-One/module-one.ins
@@ -1,0 +1,6 @@
+
+\input docstrip.tex
+\keepsilent
+\askforoverwritefalse
+\generate{\file{\jobname.sty}{\from{\jobname.dtx}{pkg}}}
+\endbatchfile

--- a/examples/Bundle-Flat/Module-One/module-one.tex
+++ b/examples/Bundle-Flat/Module-One/module-one.tex
@@ -1,0 +1,3 @@
+
+\AtBeginDocument{\OnlyDescription}
+\input{module-one.dtx}

--- a/examples/Bundle-Flat/Module-Two/build.lua
+++ b/examples/Bundle-Flat/Module-Two/build.lua
@@ -1,0 +1,10 @@
+#!/usr/bin/env texlua
+
+bundle = "bundle-flat"
+module = "module-two"
+maindir = ".."
+
+typesetfiles  = {"*.tex"}
+
+kpse.set_program_name("kpsewhich")
+dofile(kpse.lookup("l3build.lua"))

--- a/examples/Bundle-Flat/Module-Two/module-two-code.tex
+++ b/examples/Bundle-Flat/Module-Two/module-two-code.tex
@@ -1,0 +1,3 @@
+
+\AtBeginDocument{\AlsoImplementation}
+\input{module-two.dtx}

--- a/examples/Bundle-Flat/Module-Two/module-two.dtx
+++ b/examples/Bundle-Flat/Module-Two/module-two.dtx
@@ -1,0 +1,50 @@
+%
+% \iffalse
+%<*driver>
+\ProvidesFile{module-two.dtx}
+%</driver>
+%<pkg>\ProvidesPackage{module-two}
+%<*pkg>
+  [2017/12/11 v0.1 Module Two example]
+%</pkg>
+%<*driver>
+\documentclass{ltxdoc}
+\EnableCrossrefs
+\CodelineIndex
+\begin{document}
+  \DocInput{module-two.dtx}
+\end{document}
+%</driver>
+% \fi
+%
+% \GetFileInfo{module-two.dtx}
+% \title{The Module Two example}
+% \date{\fileversion \qquad \filedate}
+% \maketitle
+%
+% \begin{abstract}
+% This is the documentation of the Module Two example.
+% \end{abstract}
+%
+% \section{Introduction}
+%
+% This is where you would explain the package to a user.
+%
+% \StopEventually{}
+%
+% \section{Implementation}
+%
+%    \begin{macrocode}
+%<*pkg>
+%    \end{macrocode}
+%
+%    \begin{macrocode}
+\typeout{Actually this isn't a real package!}
+%    \end{macrocode}
+%
+%    \begin{macrocode}
+%</pkg>
+%    \end{macrocode}
+%
+% \Finale
+%

--- a/examples/Bundle-Flat/Module-Two/module-two.ins
+++ b/examples/Bundle-Flat/Module-Two/module-two.ins
@@ -1,0 +1,6 @@
+
+\input docstrip.tex
+\keepsilent
+\askforoverwritefalse
+\generate{\file{\jobname.sty}{\from{\jobname.dtx}{pkg}}}
+\endbatchfile

--- a/examples/Bundle-Flat/Module-Two/module-two.tex
+++ b/examples/Bundle-Flat/Module-Two/module-two.tex
@@ -1,0 +1,3 @@
+
+\AtBeginDocument{\OnlyDescription}
+\input{module-two.dtx}

--- a/examples/Bundle-Flat/README.md
+++ b/examples/Bundle-Flat/README.md
@@ -1,0 +1,15 @@
+L3BUILD `bundle-flat` example
+=================================================
+
+This example demonstrates a bundle of two modules, with each module arranged in a ‘flat’
+structure. There is nothing noteworthy about the modules themselves; they are based on the
+`simple-flat` example.
+
+Note the importance of the nested `build.lua` scripts, especially the setting of `maindir`
+in the build script for each module.
+
+-----
+
+Copyright (C) 2014-2017 The LaTeX3 Project <br />
+<http://latex-project.org/> <br />
+All rights reserved.

--- a/examples/Bundle-Flat/build.lua
+++ b/examples/Bundle-Flat/build.lua
@@ -1,0 +1,8 @@
+#!/usr/bin/env texlua
+
+bundle = "bundle-flat"
+
+packtdszip = true
+
+kpse.set_program_name("kpsewhich")
+dofile(kpse.lookup("l3build.lua"))

--- a/examples/Bundle-Tree/Module-One/build.lua
+++ b/examples/Bundle-Tree/Module-One/build.lua
@@ -1,0 +1,13 @@
+#!/usr/bin/env texlua
+
+bundle = "bundle-tree"
+module = "module-one"
+maindir = ".."
+
+sourcefiledir = "code"
+docfiledir    = "doc"
+typesetfiles  = {"*.dtx","*.tex"}
+packtdszip    = true -- recommended for "tree" layouts
+
+kpse.set_program_name("kpsewhich")
+dofile(kpse.lookup("l3build.lua"))

--- a/examples/Bundle-Tree/Module-One/code/module-one.dtx
+++ b/examples/Bundle-Tree/Module-One/code/module-one.dtx
@@ -1,0 +1,50 @@
+% \iffalse
+%
+%<*driver>
+\ProvidesFile{module-one.dtx}
+%</driver>
+%<pkg>\ProvidesPackage{module-one}
+%<*pkg>
+  [2017/12/10 v0.1 Module One example]
+%</pkg>
+%
+%<*driver>
+\documentclass{ltxdoc}
+\EnableCrossrefs
+\CodelineIndex
+\begin{document}
+  \DocInput{\jobname.dtx}
+\end{document}
+%</driver>
+% \fi
+%
+% \GetFileInfo{module-one.dtx}
+% \title{The \textsf{module-one} example}
+% \date{\filedate\qquad\fileversion}
+% \maketitle
+% \begin{abstract}
+% This is the implementation of the module-one example.
+% \end{abstract}
+%
+% \tableofcontents
+%
+% \section{Introduction}
+%
+% In the module-one example, code is located in code/ and documentation is located in doc/.
+%
+% \section{Implementation}
+%
+%    \begin{macrocode}
+%<*pkg>
+%    \end{macrocode}
+%
+%    \begin{macrocode}
+\typeout{Actually this isn't a real package!}
+%    \end{macrocode}
+%
+%    \begin{macrocode}
+%</pkg>
+%    \end{macrocode}
+%
+% \Finale
+%

--- a/examples/Bundle-Tree/Module-One/code/module-one.ins
+++ b/examples/Bundle-Tree/Module-One/code/module-one.ins
@@ -1,0 +1,6 @@
+
+\input docstrip.tex
+\keepsilent
+\askforoverwritefalse
+\generate{\file{\jobname.sty}{\from{\jobname.dtx}{pkg}}}
+\endbatchfile

--- a/examples/Bundle-Tree/Module-One/doc/module-one-doc.tex
+++ b/examples/Bundle-Tree/Module-One/doc/module-one-doc.tex
@@ -1,0 +1,13 @@
+\documentclass{article}
+
+\begin{document}
+
+\title{Documentation for bundle tree / module one}
+\maketitle
+
+\section{Introduction}
+
+There's not much more to say right here.
+This is where the user documentation for the example goes.
+
+\end{document}

--- a/examples/Bundle-Tree/Module-Two/build.lua
+++ b/examples/Bundle-Tree/Module-Two/build.lua
@@ -1,0 +1,13 @@
+#!/usr/bin/env texlua
+
+bundle = "bundle-tree"
+module = "module-two"
+maindir = ".."
+
+sourcefiledir = "code"
+docfiledir    = "doc"
+typesetfiles  = {"*.dtx","*.tex"}
+packtdszip    = true -- recommended for "tree" layouts
+
+kpse.set_program_name("kpsewhich")
+dofile(kpse.lookup("l3build.lua"))

--- a/examples/Bundle-Tree/Module-Two/code/module-two.dtx
+++ b/examples/Bundle-Tree/Module-Two/code/module-two.dtx
@@ -1,0 +1,50 @@
+% \iffalse
+%
+%<*driver>
+\ProvidesFile{module-two.dtx}
+%</driver>
+%<pkg>\ProvidesPackage{module-two}
+%<*pkg>
+  [2017/12/10 v0.1 Module two example]
+%</pkg>
+%
+%<*driver>
+\documentclass{ltxdoc}
+\EnableCrossrefs
+\CodelineIndex
+\begin{document}
+  \DocInput{\jobname.dtx}
+\end{document}
+%</driver>
+% \fi
+%
+% \GetFileInfo{module-two.dtx}
+% \title{The \textsf{module-two} example}
+% \date{\filedate\qquad\fileversion}
+% \maketitle
+% \begin{abstract}
+% This is the implementation of the module-two example.
+% \end{abstract}
+%
+% \tableofcontents
+%
+% \section{Introduction}
+%
+% In the module-two example, code is located in code/ and documentation is located in doc/.
+%
+% \section{Implementation}
+%
+%    \begin{macrocode}
+%<*pkg>
+%    \end{macrocode}
+%
+%    \begin{macrocode}
+\typeout{Actually this isn't a real package!}
+%    \end{macrocode}
+%
+%    \begin{macrocode}
+%</pkg>
+%    \end{macrocode}
+%
+% \Finale
+%

--- a/examples/Bundle-Tree/Module-Two/code/module-two.ins
+++ b/examples/Bundle-Tree/Module-Two/code/module-two.ins
@@ -1,0 +1,6 @@
+
+\input docstrip.tex
+\keepsilent
+\askforoverwritefalse
+\generate{\file{\jobname.sty}{\from{\jobname.dtx}{pkg}}}
+\endbatchfile

--- a/examples/Bundle-Tree/Module-Two/doc/module-two.tex
+++ b/examples/Bundle-Tree/Module-Two/doc/module-two.tex
@@ -1,0 +1,13 @@
+\documentclass{article}
+
+\begin{document}
+
+\title{Documentation for bundle tree / module two}
+\maketitle
+
+\section{Introduction}
+
+There's not much more to say right here.
+This is where the user documentation for the example goes.
+
+\end{document}

--- a/examples/Bundle-Tree/README.md
+++ b/examples/Bundle-Tree/README.md
@@ -1,0 +1,15 @@
+L3BUILD `bundle-tree` example
+=================================================
+
+This example demonstrates a bundle of two modules, with each module arranged in a ‘tree’
+structure. There is nothing noteworthy about the modules themselves; they are based on the
+`simple-tree` example.
+
+Note the importance of the nested `build.lua` scripts, especially the setting of `maindir`
+in the build script for each module.
+
+-----
+
+Copyright (C) 2014-2017 The LaTeX3 Project <br />
+<http://latex-project.org/> <br />
+All rights reserved.

--- a/examples/Bundle-Tree/build.lua
+++ b/examples/Bundle-Tree/build.lua
@@ -1,0 +1,8 @@
+#!/usr/bin/env texlua
+
+bundle = "bundle-tree"
+
+packtdszip = true
+
+kpse.set_program_name("kpsewhich")
+dofile(kpse.lookup("l3build.lua"))

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,6 +11,7 @@ The examples are:
 
 | Example                 | Description                                    |
 | ---                     | ---                                            |
+| `Simple-Flat`           | Demonstrates a simple package in a flat layout |
 | `Simple-Tree`           | Demonstrates a simple package in a tree layout |
 
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,21 @@
+l3build: a testing and building system for LaTeX3
+=================================================
+
+Examples
+--------
+
+Each sub-directory here is a self-contained example of a package set up to use `l3build`.
+These are intended for both testing and documentation purposes.
+
+The examples are:
+
+| Example                 | Description                                    |
+| ---                     | ---                                            |
+| `Simple-Tree`           | Demonstrates a simple package in a tree layout |
+
+
+-----
+
+Copyright (C) 2014-2017 The LaTeX3 Project <br />
+<http://latex-project.org/> <br />
+All rights reserved.

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,8 +11,10 @@ The examples are:
 
 | Example                 | Description                                    |
 | ---                     | ---                                            |
-| `Simple-Flat`           | Demonstrates a simple package in a flat layout |
-| `Simple-Tree`           | Demonstrates a simple package in a tree layout |
+| `Simple-Flat`           | A simple package in a flat layout |
+| `Simple-Tree`           | A simple package in a tree layout |
+| `Bundle-Flat`           | A bundle with two modules in a flat layout |
+| `Bundle-Tree`           | A bundle with two modules in a tree layout |
 
 
 -----

--- a/examples/Simple-Flat/README.md
+++ b/examples/Simple-Flat/README.md
@@ -1,0 +1,16 @@
+L3BUILD `simple-flat` example
+=================================================
+
+This is a good example demonstrating a generic use case for a simple package using `l3build`.
+
+This package is set up to produce two PDF files: one including the user documentation for the package, and the second, with ‘`-code`’ suffix, which includes both the user documentation and the typeset package code.
+Note that these are produced by the two `.tex` files, which simply set typesetting options and read in the `.dtx` docstrip file so only one source file needs to be maintained.
+
+A variety of alternative docstrip arrangements can be set up to similar effect; the arrangement here is chosen for simplicity.
+As the `.dtx` package file grows larger, it may be sensible to split it up into multiple files, including separating the user documentation from the code itself.
+
+-----
+
+Copyright (C) 2014-2017 The LaTeX3 Project <br />
+<http://latex-project.org/> <br />
+All rights reserved.

--- a/examples/Simple-Flat/build.lua
+++ b/examples/Simple-Flat/build.lua
@@ -1,0 +1,8 @@
+#!/usr/bin/env texlua
+
+module = "simple-flat"
+
+typesetfiles  = {"*.tex"}
+
+kpse.set_program_name("kpsewhich")
+dofile(kpse.lookup("l3build.lua"))

--- a/examples/Simple-Flat/simple-flat-code.tex
+++ b/examples/Simple-Flat/simple-flat-code.tex
@@ -1,0 +1,3 @@
+
+\AtBeginDocument{\AlsoImplementation}
+\input{simple-flat.dtx}

--- a/examples/Simple-Flat/simple-flat.dtx
+++ b/examples/Simple-Flat/simple-flat.dtx
@@ -1,0 +1,50 @@
+%
+% \iffalse
+%<*driver>
+\ProvidesFile{simple-flat.dtx}
+%</driver>
+%<pkg>\ProvidesPackage{simple-flat}
+%<*pkg>
+  [2017/12/11 v0.1 Simple flat example]
+%</pkg>
+%<*driver>
+\documentclass{ltxdoc}
+\EnableCrossrefs
+\CodelineIndex
+\begin{document}
+  \DocInput{simple-flat.dtx}
+\end{document}
+%</driver>
+% \fi
+%
+% \GetFileInfo{simple-flat.dtx}
+% \title{The Simple Flat example}
+% \date{\fileversion \qquad \filedate}
+% \maketitle
+%
+% \begin{abstract}
+% This is the documentation of the Simple Flat example.
+% \end{abstract}
+%
+% \section{Introduction}
+%
+% This is where you would explain the package to a user.
+%
+% \StopEventually{}
+%
+% \section{Implementation}
+%
+%    \begin{macrocode}
+%<*pkg>
+%    \end{macrocode}
+%
+%    \begin{macrocode}
+\typeout{Actually this isn't a real package!}
+%    \end{macrocode}
+%
+%    \begin{macrocode}
+%</pkg>
+%    \end{macrocode}
+%
+% \Finale
+%

--- a/examples/Simple-Flat/simple-flat.ins
+++ b/examples/Simple-Flat/simple-flat.ins
@@ -1,0 +1,6 @@
+
+\input docstrip.tex
+\keepsilent
+\askforoverwritefalse
+\generate{\file{\jobname.sty}{\from{\jobname.dtx}{pkg}}}
+\endbatchfile

--- a/examples/Simple-Flat/simple-flat.tex
+++ b/examples/Simple-Flat/simple-flat.tex
@@ -1,0 +1,3 @@
+
+\AtBeginDocument{\OnlyDescription}
+\input{simple-flat.dtx}

--- a/examples/Simple-Tree/README.md
+++ b/examples/Simple-Tree/README.md
@@ -1,0 +1,15 @@
+L3BUILD `simple-tree` example
+=================================================
+
+This is a simple example demonstrating a more complex package using `l3build`.
+Here, the code files are located in a `code/` subdirectory, and documentation files in `doc/`.
+
+In this simple case, the code and documentation consist of only one file each, which hardly seems necessary to subdivide.
+But as a package becomes larger it makes more sense to break the `.dtx` file into independent parts of the code, and the documentation can be broken itself into parts and chapters.
+This is left as an exercise to the energetic package writer studying these examples.
+
+-----
+
+Copyright (C) 2014-2017 The LaTeX3 Project <br />
+<http://latex-project.org/> <br />
+All rights reserved.

--- a/examples/Simple-Tree/build.lua
+++ b/examples/Simple-Tree/build.lua
@@ -1,0 +1,10 @@
+#!/usr/bin/env texlua
+
+module = "simple-tree"
+
+sourcefiledir = "code"
+docfiledir    = "doc"
+typesetfiles  = {"*.dtx","*.tex"}
+
+kpse.set_program_name("kpsewhich")
+dofile(kpse.lookup("l3build.lua"))

--- a/examples/Simple-Tree/build.lua
+++ b/examples/Simple-Tree/build.lua
@@ -5,6 +5,7 @@ module = "simple-tree"
 sourcefiledir = "code"
 docfiledir    = "doc"
 typesetfiles  = {"*.dtx","*.tex"}
+packtdszip    = true -- recommended for "tree" layouts
 
 kpse.set_program_name("kpsewhich")
 dofile(kpse.lookup("l3build.lua"))

--- a/examples/Simple-Tree/code/simple-tree.dtx
+++ b/examples/Simple-Tree/code/simple-tree.dtx
@@ -1,0 +1,50 @@
+% \iffalse
+%
+%<*driver>
+\ProvidesFile{simple-tree.dtx}
+%</driver>
+%<pkg>\ProvidesPackage{simple-tree}
+%<*pkg>
+  [2017/12/10 v0.1 Simple tree example]
+%</pkg>
+%
+%<*driver>
+\documentclass{ltxdoc}
+\EnableCrossrefs
+\CodelineIndex
+\begin{document}
+  \DocInput{\jobname.dtx}
+\end{document}
+%</driver>
+% \fi
+%
+% \GetFileInfo{simple-tree.dtx}
+% \title{The \textsf{simple-tree} example}
+% \date{\filedate\qquad\fileversion}
+% \maketitle
+% \begin{abstract}
+% This is the implementation of the simple-tree example.
+% \end{abstract}
+%
+% \tableofcontents
+%
+% \section{Introduction}
+%
+% In the simple-tree example, code is located in code/ and documentation is located in doc/.
+%
+% \section{Implementation}
+%
+%    \begin{macrocode}
+%<*pkg>
+%    \end{macrocode}
+%
+%    \begin{macrocode}
+\typeout{Actually this isn't a real package!}
+%    \end{macrocode}
+%
+%    \begin{macrocode}
+%</pkg>
+%    \end{macrocode}
+%
+% \Finale
+%

--- a/examples/Simple-Tree/code/simple-tree.ins
+++ b/examples/Simple-Tree/code/simple-tree.ins
@@ -1,0 +1,6 @@
+
+\input docstrip.tex
+\keepsilent
+\askforoverwritefalse
+\generate{\file{\jobname.sty}{\from{\jobname.dtx}{pkg}}}
+\endbatchfile

--- a/examples/Simple-Tree/doc/simple-tree-doc.tex
+++ b/examples/Simple-Tree/doc/simple-tree-doc.tex
@@ -1,0 +1,13 @@
+\documentclass{article}
+
+\begin{document}
+
+\title{Documentation for simple tree example}
+\maketitle
+
+\section{Introduction}
+
+There's not much more to say right here.
+This is where the user documentation for the simple tree example goes.
+
+\end{document}

--- a/l3build.dtx
+++ b/l3build.dtx
@@ -57,10 +57,11 @@
 \luavarset{modules}{\{\}}{The list of all modules in a bundle (when not auto-detecting)}
 \luavarset{exclmodules}{\{\}}{Directories to be excluded from automatic module detection}
 \luavarseparator
-\luavarset{maindir}    {"."}                      {Top level directory for the module/bundle}
-\luavarset{docfiledir} {maindir}                  {Directory containing documentation files}
+\luavarset{maindir}     {"."}                      {Top level directory for the module/bundle}
+\luavarset{docfiledir}  {"."}                 {Directory containing documentation files}
+\luavarset{sourcfiledir}{"."}                 {Directory containing source files}
 \luavarset{supportdir} {maindir .. "/support"}    {Directory containing general support files}
-\luavarset{testfiledir}{maindir .. "/testfiles"}  {Directory containing test files}
+\luavarset{testfiledir}{"./testfiles"}  {Directory containing test files}
 \luavarset{testsuppdir}{testfiledir .. "/support"}{Directory containing test-specific support files}
 \luavarseparator
 \luavarset{builddir}  {maindir .. "/build"}   {Directory for building and testing}
@@ -679,6 +680,14 @@
 % This ensures that the \pkg{l3kernel} code is included in all processes involved in unpacking and checking and so on.
 % The name of the script file in the dependency is set with the |scriptname| variable; by default these are |"build.lua"|.
 %
+% \subsection{Non-standard source layouts}
+%
+% A variety of source layouts are supported. In general, a \enquote{flat}
+% layout with all source files \enquote{here} is most convenient. However,
+% \pkg{l3build} supports placement of both code and documentation source
+% files in other locations using the \var{sourcefiledir} and \var{docfiledir}
+% variables. For pre-built trees, the glob syntax |**/*| may be useful in these
+% cases: this enables recursive searching in the appropriate tree locations.
 %
 % \subsection{Output normalisation}
 % \label{sec:norm}

--- a/l3build.dtx
+++ b/l3build.dtx
@@ -63,11 +63,12 @@
 \luavarset{testfiledir}{maindir .. "/testfiles"}  {Directory containing test files}
 \luavarset{testsuppdir}{testfiledir .. "/support"}{Directory containing test-specific support files}
 \luavarseparator
-\luavarset{distribdir}{maindir .. "/build/distrib"}{Directory for generating distribution structure}
-\luavarset{localdir}  {maindir .. "/build/local"}  {Directory for extracted files in \enquote{sandboxed} \TeX{} runs}
-\luavarset{testdir}   {maindir .. "/build/test"}   {Directory for running tests}
-\luavarset{typesetdir}{maindir .. "/build/doc"}    {Directory for building documentation}
-\luavarset{unpackdir} {maindir .. "/build/unpack"} {Directory for unpacking sources}
+\luavarset{builddir}  {maindir .. "/build"}   {Directory for building and testing}
+\luavarset{distribdir}{builddir .. "/distrib"}{Directory for generating distribution structure}
+\luavarset{localdir}  {builddir .. "/local"}  {Directory for extracted files in \enquote{sandboxed} \TeX{} runs}
+\luavarset{testdir}   {builddir .. "/test"}   {Directory for running tests}
+\luavarset{typesetdir}{builddir .. "/doc"}    {Directory for building documentation}
+\luavarset{unpackdir} {builddir .. "/unpack"} {Directory for unpacking sources}
 \luavarseparator
 \luavarset{ctandir}{distribdir .. "/ctan"}{Directory for organising files for CTAN}
 \luavarset{tdsdir} {distribdir .. "/tds"} {Directory for organised files into TDS structure}

--- a/l3build.lua
+++ b/l3build.lua
@@ -863,7 +863,6 @@ function copyctan()
   local ctantarget = ctanpkg
   if docfiledir ~= currentdir then
     ctantarget = ctanpkg .. "/" .. gsub(docfiledir, "^%.*/", "")
-    print(ctantarget)
   end
   for _,filetype in pairs(
       {

--- a/l3build.lua
+++ b/l3build.lua
@@ -2069,7 +2069,7 @@ function bundlectan()
   local function excludelist(include, exclude, dir)
     local include = include or { }
     local exclude = exclude or { }
-    local dir = dir or currendir
+    local dir = dir or currentdir
     local includelist = { }
     local excludelist = { }
     for _,i in ipairs(exclude) do

--- a/l3build.lua
+++ b/l3build.lua
@@ -70,11 +70,12 @@ testfiledir = testfiledir or "testfiles"
 testsuppdir = testsuppdir or testfiledir .. "/support"
 
 -- Structure within a development area
-distribdir = distribdir or maindir .. "/build/distrib"
-localdir   = localdir   or maindir .. "/build/local"
-testdir    = testdir    or maindir .. "/build/test"
-typesetdir = typesetdir or maindir .. "/build/doc"
-unpackdir  = unpackdir  or maindir .. "/build/unpacked"
+builddir   = builddir   or maindir .. "/build"
+distribdir = distribdir or builddir .. "/distrib"
+localdir   = localdir   or builddir .. "/local"
+testdir    = testdir    or builddir .. "/test"
+typesetdir = typesetdir or builddir .. "/doc"
+unpackdir  = unpackdir  or builddir .. "/unpacked"
 
 -- Substructure for CTAN release material
 ctandir = ctandir or distribdir .. "/ctan"
@@ -691,7 +692,7 @@ function tree(path, glob)
       for _, file in ipairs(filelist(dir, pattern)) do
         local fullpath = path .. "/" .. file
         if file ~= "." and file ~= ".." and
-          fullpath ~= maindir .. "/build" and
+          fullpath ~= builddir and
           (sub(pattern, 1, 1) == "."
             or sub(file, 1, 1) ~= ".")
         then

--- a/l3build.lua
+++ b/l3build.lua
@@ -66,7 +66,7 @@ maindir = maindir or "."
 -- Substructure for file locations
 docfiledir  = docfiledir  or maindir
 supportdir  = supportdir  or maindir .. "/support"
-testfiledir = testfiledir or "testfiles"
+testfiledir = testfiledir or maindir .. "/testfiles"
 testsuppdir = testsuppdir or testfiledir .. "/support"
 
 -- Structure within a development area

--- a/l3build.lua
+++ b/l3build.lua
@@ -61,12 +61,13 @@ end
 
 -- Directory structure for the build system
 -- Use Unix-style path separators
-maindir = maindir or "."
+currentdir = "."
+maindir    = maindir or currentdir
 
 -- Substructure for file locations
-docfiledir  = docfiledir  or maindir
+docfiledir  = docfiledir  or currentdir
 supportdir  = supportdir  or maindir .. "/support"
-testfiledir = testfiledir or maindir .. "/testfiles"
+testfiledir = testfiledir or currentdir .. "/testfiles"
 testsuppdir = testsuppdir or testfiledir .. "/support"
 
 -- Structure within a development area
@@ -838,7 +839,7 @@ function checkinit()
   for _,i in ipairs(filelist(localdir)) do
     cp(i, localdir, testdir)
   end
-  bundleunpack({".", testfiledir})
+  bundleunpack({currentdir, testfiledir})
   for _,i in ipairs(installfiles) do
     cp(i, unpackdir, testdir)
   end
@@ -871,7 +872,7 @@ function copyctan()
       }
     ) do
     for _,j in ipairs(i) do
-      cp(j, ".", ctandir .. "/" .. ctanpkg)
+      cp(j, currentdir, ctandir .. "/" .. ctanpkg)
     end
   end
 end
@@ -918,7 +919,7 @@ function copytds()
   )
   install(unpackdir, "makeindex", {makeindexfiles}, true)
   install(unpackdir, "bibtex/bst", {bstfiles}, true)
-  install(".", "source", {sourcelist})
+  install(currentdir, "source", {sourcelist})
   install(unpackdir, "tex", {installfiles})
 end
 
@@ -1921,7 +1922,7 @@ function clean()
     cleandir(typesetdir) +
     cleandir(unpackdir)
   for _,i in ipairs(cleanfiles) do
-    errorlevel = rm(".", i) + errorlevel
+    errorlevel = rm(currentdir, i) + errorlevel
   end
   return errorlevel
 end
@@ -1929,7 +1930,7 @@ end
 function bundleclean()
   local errorlevel = call(modules, "clean")
   for _,i in ipairs(cleanfiles) do
-    errorlevel = rm(".", i) + errorlevel
+    errorlevel = rm(maindir, i) + errorlevel
   end
   return (
     errorlevel     +
@@ -1945,7 +1946,7 @@ function cmdcheck()
   depinstall(checkdeps)
   for _,i in ipairs({bibfiles, docfiles, sourcefiles, typesetfiles}) do
     for _,j in ipairs(i) do
-      cp(j, ".", testdir)
+      cp(j, currentdir, testdir)
     end
   end
   for _,i in ipairs(typesetsuppfiles) do
@@ -1955,7 +1956,7 @@ function cmdcheck()
   local localdir = abspath(localdir)
   print("Checking source files")
   for _,i in ipairs(cmdchkfiles) do
-    for _,j in ipairs(filelist(".", i)) do
+    for _,j in ipairs(filelist(currentdir, i)) do
       print("  " .. jobname(j))
       run(
         testdir,
@@ -2031,7 +2032,7 @@ function ctan(standalone)
   end
   if errorlevel == 0 then
     for _,i in ipairs(textfiles) do
-      for _,j in pairs({unpackdir, "."}) do
+      for _,j in pairs({unpackdir, currentdir}) do
         cp(i, j, ctandir .. "/" .. ctanpkg)
         cp(i, j, tdsdir .. "/doc/" .. tdsroot .. "/" .. bundle)
       end
@@ -2041,7 +2042,7 @@ function ctan(standalone)
       cp(ctanpkg .. ".tds.zip", tdsdir, ctandir)
     end
     dirzip(ctandir, ctanpkg)
-    cp(ctanpkg .. ".zip", ctandir, ".")
+    cp(ctanpkg .. ".zip", ctandir, currentdir)
   else
     print("\n====================")
     print("Typesetting failed, zip stage skipped!")
@@ -2060,13 +2061,13 @@ function bundlectan()
     local excludelist = { }
     for _,i in ipairs(exclude) do
       for _,j in ipairs(i) do
-        for _,k in ipairs(filelist(".", j)) do
+        for _,k in ipairs(filelist(currentdir, j)) do
           excludelist[k] = true
         end
       end
     end
     for _,i in ipairs(include) do
-      for _,j in ipairs(filelist(".", i)) do
+      for _,j in ipairs(filelist(currentdir, i)) do
         if not excludelist[j] then
           insert(includelist, j)
         end
@@ -2114,7 +2115,7 @@ function doc(files)
     cp(i, supportdir, typesetdir)
   end
   depinstall(typesetdeps)
-  unpack({sourcefiles, typesetsourcefiles}, {".", docfiledir})
+  unpack({sourcefiles, typesetsourcefiles}, {currentdir, docfiledir})
   -- Main loop for doc creation
   local done = {}
   for _, typesetfiles in ipairs({typesetdemofiles, typesetfiles}) do
@@ -2312,7 +2313,7 @@ function setversion(dir)
   end
   local date = options["date"] or os_date("%Y-%m-%d")
   local version = options["version"] or -1
-  local dir = dir or "."
+  local dir = dir or currentdir
   for _,i in pairs(versionfiles) do
     for _,j in pairs(filelist(dir, i)) do
       rewrite(dir, j, date, version)
@@ -2352,7 +2353,7 @@ bundleunpack = bundleunpack or function(sourcedirs, sources)
   if errorlevel ~=0 then
     return errorlevel
   end
-  for _,i in ipairs(sourcedirs or {"."}) do
+  for _,i in ipairs(sourcedirs or {currentdir}) do
     for _,j in ipairs(sources or {sourcefiles}) do
       for _,k in ipairs(j) do
         errorlevel = cp(k, i, unpackdir)

--- a/l3build.lua
+++ b/l3build.lua
@@ -612,7 +612,7 @@ function cp(glob, source, dest)
       else
         errorlevel = execute(
           'xcopy /y "' .. unix_to_win(source) .. '" "'
-             .. unix_to_win(dest) .. '" > nul'
+             .. unix_to_win(dest .. '/') .. '" > nul'
         )
       end
     else

--- a/l3build.lua
+++ b/l3build.lua
@@ -866,6 +866,7 @@ function copyctan()
   if docfiledir ~= currentdir then
     ctantarget = ctanpkg .. "/" .. gsub(docfiledir, "^%.*/", "")
   end
+  mkdir(ctandir .. "/" .. ctantarget)
   for _,filetype in pairs(
       {
         bibfiles,
@@ -884,6 +885,7 @@ function copyctan()
     ctantarget = ctanpkg .. "/" .. gsub(sourcefiledir, "^%.*/", "")
     print(ctantarget)
   end
+  mkdir(ctandir .. "/" .. ctantarget)
   for _,file in pairs(sourcefiles) do
     if sourcedir ~= currentdir then
     end

--- a/l3build.lua
+++ b/l3build.lua
@@ -883,7 +883,6 @@ function copyctan()
   ctantarget = ctanpkg
   if sourcefiledir ~= currentdir then
     ctantarget = ctanpkg .. "/" .. gsub(sourcefiledir, "^%.*/", "")
-    print(ctantarget)
   end
   mkdir(ctandir .. "/" .. ctantarget)
   for _,file in pairs(sourcefiles) do

--- a/l3build.lua
+++ b/l3build.lua
@@ -743,6 +743,8 @@ end
 function ren(dir, source, dest)
   local dir = dir .. "/"
   if os_type == "windows" then
+    local source = gsub(source, "^%.+/", "")
+    local dest = gsub(dest, "^%.+/", "")
     return execute("ren " .. unix_to_win(dir) .. source .. " " .. dest)
   else
     return execute("mv " .. dir .. source .. " " .. dir .. dest)

--- a/l3build.lua
+++ b/l3build.lua
@@ -860,7 +860,11 @@ end
 
 -- Copy files to the main CTAN release directory
 function copyctan()
-  -- Do all of the copying in one go
+  local ctantarget = ctanpkg
+  if docfiledir ~= currentdir then
+    ctantarget = ctanpkg .. "/" .. gsub(docfiledir, "^%.*/", "")
+    print(ctantarget)
+  end
   for _,filetype in pairs(
       {
         bibfiles,
@@ -871,11 +875,18 @@ function copyctan()
       }
     ) do
     for _,file in pairs(filetype) do
-      cp(file, docfiledir, ctandir .. "/" .. ctanpkg)
+      cp(file, docfiledir, ctandir .. "/" .. ctantarget)
     end
   end
+  ctantarget = ctanpkg
+  if sourcefiledir ~= currentdir then
+    ctantarget = ctanpkg .. "/" .. gsub(sourcefiledir, "^%.*/", "")
+    print(ctantarget)
+  end
   for _,file in pairs(sourcefiles) do
-    cp(file, sourcefiledir, ctandir .. "/" .. ctanpkg)
+    if sourcedir ~= currentdir then
+    end
+    cp(file, sourcefiledir, ctandir .. "/" .. ctantarget)
   end
   for _,file in pairs(textfiles) do
     cp(file, currentdir, ctandir .. "/" .. ctanpkg)

--- a/l3build.lua
+++ b/l3build.lua
@@ -65,10 +65,10 @@ currentdir = "."
 maindir    = maindir or currentdir
 
 -- Substructure for file locations
-docfiledir  = docfiledir  or currentdir
-supportdir  = supportdir  or maindir .. "/support"
-testfiledir = testfiledir or currentdir .. "/testfiles"
-testsuppdir = testsuppdir or testfiledir .. "/support"
+docfiledir    = docfiledir    or currentdir
+supportdir    = supportdir    or maindir .. "/support"
+testfiledir   = testfiledir   or currentdir .. "/testfiles"
+testsuppdir   = testsuppdir   or testfiledir .. "/support"
 
 -- Structure within a development area
 builddir   = builddir   or maindir .. "/build"

--- a/l3build.lua
+++ b/l3build.lua
@@ -903,8 +903,8 @@ function copytds()
     local filenames = { }
     for _,i in ipairs(files) do
       for _,j in ipairs(i) do
-        for _,k in ipairs(filelist(source, j)) do
-          insert(filenames, k)
+        for file,_ in pairs(tree(source, j)) do
+          insert(filenames, file)
         end
       end
     end
@@ -2074,15 +2074,15 @@ function bundlectan()
     local excludelist = { }
     for _,i in ipairs(exclude) do
       for _,j in ipairs(i) do
-        for _,k in ipairs(filelist(dir, j)) do
-          excludelist[k] = true
+        for file,_ in pairs(tree(dir, j)) do
+          excludelist[file] = true
         end
       end
     end
     for _,i in ipairs(include) do
-      for _,j in ipairs(filelist(dir, i)) do
-        if not excludelist[j] then
-          insert(includelist, j)
+      for file,_ in pairs(tree(dir, i)) do
+        if not excludelist[file] then
+          insert(includelist, file)
         end
       end
     end
@@ -2331,8 +2331,8 @@ function setversion()
   local version = options["version"] or -1
   for _,dir in pairs({currentdir, sourcefiledir, docfiledir}) do
     for _,i in pairs(versionfiles) do
-      for _,j in pairs(filelist(dir, i)) do
-        rewrite(dir, j, date, version)
+      for file,_ in pairs(tree(dir, i)) do
+        rewrite(dir, file, date, version)
       end
     end
   end

--- a/l3build.lua
+++ b/l3build.lua
@@ -860,19 +860,22 @@ end
 -- Copy files to the main CTAN release directory
 function copyctan()
   -- Do all of the copying in one go
-  for _,i in ipairs(
+  for _,filetype in pairs(
       {
         bibfiles,
         demofiles,
         docfiles,
         pdffiles,
-        sourcefiles,
-        textfiles,
         typesetlist
       }
     ) do
-    for _,j in ipairs(i) do
-      cp(j, currentdir, ctandir .. "/" .. ctanpkg)
+    for _,file in pairs(filetype) do
+      cp(file, docfiledir, ctandir .. "/" .. ctanpkg)
+    end
+  end
+  for _,filetype in pairs({sourcefiles, textfiles}) do
+    for _,file in pairs(filetype) do
+      cp(file, currentdir, ctandir .. "/" .. ctanpkg)
     end
   end
 end
@@ -913,7 +916,7 @@ function copytds()
     end
   end
   install(
-    ".",
+    docfiledir,
     "doc",
     {bibfiles, demofiles, docfiles, pdffiles, textfiles, typesetlist}
   )
@@ -1748,7 +1751,7 @@ function typesetpdf(file, dir)
   if errorlevel == 0 then
     name = name .. ".pdf"
     os_remove(jobname(name))
-    cp(name, typesetdir, ".")
+    cp(name, typesetdir, docfiledir)
   else
     print(" ! Compilation failed")
   end
@@ -1944,13 +1947,18 @@ function cmdcheck()
   mkdir(localdir)
   cleandir(testdir)
   depinstall(checkdeps)
-  for _,i in ipairs({bibfiles, docfiles, sourcefiles, typesetfiles}) do
-    for _,j in ipairs(i) do
-      cp(j, currentdir, testdir)
+  for _,filetype in pairs(
+      {bibfiles, docfiles, typesetfiles, typesetdemofiles}
+    ) do
+    for _,file in pairs(filetype) do
+      cp(file, docfiledir, typesetdir)
     end
   end
-  for _,i in ipairs(typesetsuppfiles) do
-    cp(i, supportdir, testdir)
+  for _,file in pairs(sourcefiles) do
+    cp(file, currentdir, testdir)
+  end
+  for _,file in pairs(typesetsuppfiles) do
+    cp(file, supportdir, testdir)
   end
   local engine = gsub(stdengine, "tex$", "latex")
   local localdir = abspath(localdir)
@@ -2104,15 +2112,18 @@ end
 function doc(files)
   -- Set up
   cleandir(typesetdir)
-  for _,i in ipairs(
-    {bibfiles, docfiles, sourcefiles, typesetfiles, typesetdemofiles}
-  ) do
-    for _,j in ipairs(i) do
-      cp(j, ".", typesetdir)
-    end
-  end
-  for _,i in ipairs(typesetsuppfiles) do
-    cp(i, supportdir, typesetdir)
+  for _,filetype in pairs( 
+      {bibfiles, docfiles, typesetfiles, typesetdemofiles} 
+    ) do 
+    for _,file in pairs(filetype) do 
+      cp(file, docfiledir, typesetdir) 
+    end 
+  end 
+  for _,file in pairs(sourcefiles) do 
+    cp(file, currentdir, typesetdir) 
+  end 
+  for _,file in pairs(typesetsuppfiles) do
+    cp(file, supportdir, typesetdir)
   end
   depinstall(typesetdeps)
   unpack({sourcefiles, typesetsourcefiles}, {currentdir, docfiledir})


### PR DESCRIPTION
A second attempt at this: this time tested against a bundle set up too!

Various minor issues with docfiledir are fixed as part of this pull request.

Some minor issues remain concerning whether _e.g._ `textfiles` look 'here' or not. At this stage, I suggest we leave them alone and only add more vars as needed for real cases.