### PR TITLE
Improve messages for the save command

### DIFF
--- a/l3build-check.lua
+++ b/l3build-check.lua
@@ -960,6 +960,10 @@ end
 function save(names)
   checkinit()
   local engines = options["engine"] or {stdengine}
+  if names == nil then
+    print("Arguments are required for the save command")
+    return 1
+  end
   for _,name in pairs(names) do
     if testexists(name) then
       for _,engine in pairs(engines) do
@@ -991,7 +995,7 @@ function save(names)
         .. lveext .. " file of the same name")
       return 1
     else
-      print('Test "'.. name .. '"not found')
+      print('Test "' .. name .. '" not found')
       return 1
     end
   end


### PR DESCRIPTION
Trying to execute the `save` command without any argument results in the following:

```
$ ./build.lua save
.../l3build/l3build-check.lua:961: bad argument #1 to 'for iterator' (table expected, got nil)
```

According to the documentation, the `save` command requires at least an argument, so it is fine to fail in the situation. However, the Lua-level error message `bad argument #1 to 'for iterator'` is something we don't want to see. I improved it to provide a better indication:

```
$ ./build.lua save
Arguments are required for the save command

$ echo $?
1
```

At the same time, a trivial spacing error in the same function `save()` has been fixed.