### PR TITLE
Normalize lua data references

### DIFF
--- a/l3build-check.lua
+++ b/l3build-check.lua
@@ -251,6 +251,9 @@ local function normalize_log(content,engine,errlevels)
     line = gsub(line, "save cache:", "load cache:")
     -- A tidy-up to keep LuaTeX and other engines in sync
     line = gsub(line, utf8_char(127), "^^?")
+    -- Remove lua data reference ids
+    line = gsub(line, "<lua data reference [0-9]+>",
+                      "<lua data reference ...>")
     -- Unicode engines display chars in the upper half of the 8-bit range:
     -- tidy up to match pdfTeX if an ASCII engine is in use
     if next(asciiengines) then

--- a/l3build.dtx
+++ b/l3build.dtx
@@ -845,6 +845,9 @@
 %     \texttt{\cs{\meta{type}}\meta{...}}
 %   \item Conversion of box numbers in |\show| lines
 %     \texttt{>~\cs{box}\meta{number}=} to \texttt{>~\cs{box}...=}
+%   \item Conversion of Lua data reference ids
+%     \texttt{<lua data reference \meta{number}>} to
+%     \texttt{<lua data reference ...>}
 %   \item Removal of some (u)p\TeX{} data where it is equivalent to
 %     \pdfTeX{} (|yoko direction|, |\displace 0.0|)
 % \end{itemize}


### PR DESCRIPTION
Some values contained in nodes are represented by Lua values in LuaTeX. This leds LuaTeX to print log output like
```
....\pdfliteral page <lua data reference 792>
```
where the number is highly version dependent and not meaningful. I suggest normalizing these to `reference ...>`.