### PR TITLE
Avoid temporary file when passing "y" in unpack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ this project uses date-based 'snapshot' version identifiers.
 ### Changed
 - Avoid temporary file when unpacking
 
+### Deprecated
+- `os_yes`: use `io.popen(...,w)` instead
+
 ## [2020-02-17]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Changed
+- Avoid temporary file when unpacking
+
 ## [2020-02-17]
 
 ### Added

--- a/l3build-unpack.lua
+++ b/l3build-unpack.lua
@@ -73,26 +73,20 @@ bundleunpack = bundleunpack or function(sourcedirs, sources)
   end
   for _,i in ipairs(unpackfiles) do
     for j,_ in pairs(tree(unpackdir, i)) do
-      -- This 'yes' business is needed to pass a series of "y\n" to
-      -- TeX if \askforoverwrite is true
-      -- That is all done using a file as it's the only way on Windows and
-      -- on Unix the "yes" command can't be used inside execute (it never
-      -- stops, which confuses Lua)
-      execute(os_yes .. ">>" .. localdir .. "/yes")
       local path, name = splitpath(j)
       local localdir = abspath(localdir)
-      errorlevel = run(
-        unpackdir .. "/" .. path,
+      errorlevel = io.popen(
+        "cd " .. unpackdir .. "/" .. path .. os_concat ..
         os_setenv .. " TEXINPUTS=." .. os_pathsep
           .. localdir .. (unpacksearch and os_pathsep or "") ..
         os_concat  ..
         os_setenv .. " LUAINPUTS=." .. os_pathsep
           .. localdir .. (unpacksearch and os_pathsep or "") ..
         os_concat ..
-        unpackexe .. " " .. unpackopts .. " " .. name .. " < "
-          .. localdir .. "/yes"
-          .. (options["quiet"] and (" > " .. os_null) or "")
-      )
+        unpackexe .. " " .. unpackopts .. " " .. name
+          .. (options["quiet"] and (" > " .. os_null) or ""),
+        "w"
+      ):write(string.rep("y\n", 300)):close()
       if errorlevel ~=0 then
         return errorlevel
       end

--- a/l3build-unpack.lua
+++ b/l3build-unpack.lua
@@ -75,7 +75,7 @@ bundleunpack = bundleunpack or function(sourcedirs, sources)
     for j,_ in pairs(tree(unpackdir, i)) do
       local path, name = splitpath(j)
       local localdir = abspath(localdir)
-      errorlevel = io.popen(
+      local success = io.popen(
         "cd " .. unpackdir .. "/" .. path .. os_concat ..
         os_setenv .. " TEXINPUTS=." .. os_pathsep
           .. localdir .. (unpacksearch and os_pathsep or "") ..
@@ -87,8 +87,8 @@ bundleunpack = bundleunpack or function(sourcedirs, sources)
           .. (options["quiet"] and (" > " .. os_null) or ""),
         "w"
       ):write(string.rep("y\n", 300)):close()
-      if errorlevel ~=0 then
-        return errorlevel
+      if not success then
+        return 1
       end
     end
   end

--- a/l3build.dtx
+++ b/l3build.dtx
@@ -1776,6 +1776,7 @@
 % \end{variable}
 %
 % \begin{variable}{os_yes}
+%   \textbf{DEPRECATED}
 %   A command to generate a series of $200$ lines each containing the
 %   character |y|: this is useful as the Unix |yes| command cannot be
 %   used inside |os.execute| (it does not terminate).


### PR DESCRIPTION
Mostly I just don't like temporary files and I interpreted the statement "as it's the only way on Windows" as a challenge.
Also this avoids the need for a system-dependent `os_yes` command.

This PR does not delete the `os_yes` variable to keep compatibility with build.lua files which might rely on it.