### PR TITLE
Reference to https://www.ctan.org/upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,3 @@ build/
 *.zip
 !testfiles/*.pdf
 
-l3build.glo
-l3build.hd
-l3build.idx
-l3build.log
-l3build.out
-l3build.synctex.gz
-l3build.toc
-l3build.aux

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,11 @@ build/
 *.zip
 !testfiles/*.pdf
 
+l3build.glo
+l3build.hd
+l3build.idx
+l3build.log
+l3build.out
+l3build.synctex.gz
+l3build.toc
+l3build.aux

--- a/l3build.dtx
+++ b/l3build.dtx
@@ -1426,7 +1426,7 @@
 %
 % The CTAN upload process is backed by an API, which \pkg{l3build} can use
 % to send zip files for release. Along with the file, a variety of metadata
-% must be specified about the package, including the version, license, and so on.
+% must be specified about the package, including the version, license, and so on, explained at \url{https://www.ctan.org/upload}.
 % A description of this metadata is outlined in Table~\ref{tab:upload-setup},
 % and a simple example of an extract from a \texttt{build.lua} file using this is shown
 % in Figure~\ref{fig:uploadconfig}.


### PR DESCRIPTION
The actual documentation refers to the CTAN upload API which the end user won't use directly.
Instead explicitly referring to the web page is extremely useful and efficient.

BTW, ignoring auxiliary files allows to typeset the dtx file from a standard tex editor without messing up the repository.