### PR TITLE
Revamping l3build-arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.*
+!/.gitignore
+
 build/
 *.pdf
 *.zip

--- a/l3build-aux.lua
+++ b/l3build-aux.lua
@@ -68,7 +68,7 @@ end
 -- Do some subtarget for all modules in a bundle
 function call(dirs, target, opts)
   -- Turn the option table into a string
-  local opts = opts or options
+  local opts = opts or Opts
   local s = ""
   for k,v in pairs(opts) do
     if k ~= "names" and k ~= "target" then -- Special cases

--- a/l3build-aux.lua
+++ b/l3build-aux.lua
@@ -72,7 +72,7 @@ function call(dirs, target, opts)
   local s = ""
   for k,v in pairs(opts) do
     if k ~= "names" and k ~= "target" then -- Special cases
-      local t = option_list[k] or { }
+      local t = A.option_list[k] or { }
       local arg = ""
       if t["type"] == "string" then
         arg = arg .. "=" .. v

--- a/l3build-check.lua
+++ b/l3build-check.lua
@@ -55,7 +55,7 @@ local remove           = os.remove
 -- Set up the check system files: needed for checking one or more tests and
 -- for saving the test files
 function checkinit()
-  if not options["dirty"] then
+  if not Opts.dirty then
     cleandir(testdir)
     cleandir(resultdir)
   end
@@ -562,8 +562,8 @@ function runcheck(name, hide)
     return 1
   end
   local checkengines = checkengines
-  if options["engine"] then
-    checkengines = options["engine"]
+  if Opts.engine then
+    checkengines = Opts.engine
   end
   -- Used for both .lvt and .pvt tests
   local function check_and_diff(ext,engine,comp,pdftest)
@@ -572,10 +572,10 @@ function runcheck(name, hide)
     if errorlevel == 0 then
       return errorlevel
     end
-    if options["show-log-on-error"] then
+    if Opts["show-log-on-error"] then
       showfailedlog(name)
     end
-    if options["halt-on-error"] then
+    if Opts["halt-on-error"] then
       showfaileddiff()
     end
     return errorlevel
@@ -589,7 +589,7 @@ function runcheck(name, hide)
     else
       errlevel = check_and_diff(lvtext,engine,compare_tlg)
     end
-    if errlevel ~= 0 and options["halt-on-error"] then
+    if errlevel ~= 0 and Opts["halt-on-error"] then
       return 1
     end
     if errlevel > errorlevel then
@@ -838,7 +838,7 @@ end
 function check(names)
   local errorlevel = 0
   if testfiledir ~= "" and direxists(testfiledir) then
-    if not options["rerun"] then
+    if not Opts.rerun then
       checkinit()
     end
     local hide = true
@@ -882,10 +882,10 @@ function check(names)
       end
       sort(names)
       -- Deal limiting range of names
-      if options["first"] then
+      if Opts.first then
         local allnames = names
         local active = false
-        local firstname = options["first"]
+        local firstname = Opts.first
         names = { }
         for _,name in ipairs(allnames) do
           if name == firstname then
@@ -896,9 +896,9 @@ function check(names)
           end
         end
       end
-      if options["last"] then
+      if Opts.last then
         local allnames = names
-        local lastname = options["last"]
+        local lastname = Opts.last
         names = { }
         for _,name in ipairs(allnames) do
           insert(names,name)
@@ -917,7 +917,7 @@ function check(names)
       end
       return tbl
     end
-    if options["shuffle"] then
+    if Opts.shuffle then
       names = shuffle(names)
     end
     -- Actually run the tests
@@ -929,7 +929,7 @@ function check(names)
       local errlevel = runcheck(name, hide)
       -- Return value must be 1 not errlevel
       if errlevel ~= 0 then
-        if options["halt-on-error"] then
+        if Opts["halt-on-error"] then
           return 1
         else
           errorlevel = 1
@@ -986,7 +986,7 @@ end
 
 function save(names)
   checkinit()
-  local engines = options["engine"] or {stdengine}
+  local engines = Opts.engine or {stdengine}
   if names == nil then
     print("Arguments are required for the save command")
     return 1

--- a/l3build-ctan.lua
+++ b/l3build-ctan.lua
@@ -67,7 +67,7 @@ end
 
 function ctan()
   -- Always run tests for all engines
-  options["engine"] = nil
+  Opts.engine = nil
   local function dirzip(dir, name)
     local zipname = name .. ".zip"
     local function tab_to_str(table)

--- a/l3build-help.lua
+++ b/l3build-help.lua
@@ -72,7 +72,7 @@ function help()
   print("Valid options are:")
   local longest,t = setup_list(option_list)
   for _,k in ipairs(t) do
-    local opt = option_list[k]
+    local opt = A.option_list[k]
     local filler = rep(" ", longest - k:len() + 1)
     if opt["desc"] then
       if opt["short"] then

--- a/l3build-install.lua
+++ b/l3build-install.lua
@@ -37,13 +37,13 @@ local insert = table.insert
 
 local function gethome()
   set_program("latex")
-  return abspath(options["texmfhome"] or var_value("TEXMFHOME"))
+  return abspath(Opts.texmfhome or var_value("TEXMFHOME"))
 end
 
 function uninstall()
   local function zapdir(dir)
     local installdir = gethome() .. "/" .. dir
-    if options["dry-run"] then
+    if Opts["dry-run"] then
       local files = filelist(installdir)
       if next(files) then
         print("\n" .. "For removal from " .. installdir .. ":")
@@ -72,7 +72,7 @@ function uninstall()
       -- Man files should have a single-digit extension: the type
       local installdir = gethome() .. "/doc/man/man"  .. match(file,".$")
       if fileexists(installdir .. "/" .. file) then
-        if options["dry-run"] then
+        if Opts["dry-run"] then
           insert(manfiles,"man" .. match(file,".$") .. "/" ..
            select(2,splitpath(file)))
         else
@@ -294,5 +294,5 @@ function install_files(target,full,dry_run)
 end
 
 function install()
-  return install_files(gethome(),options["full"],options["dry-run"])
+  return install_files(gethome(),Opts.full,Opts["dry-run"])
 end

--- a/l3build-tagging.lua
+++ b/l3build-tagging.lua
@@ -62,7 +62,7 @@ local function update_file_tag(file,tagname,tagdate)
 end
 
 function tag(tagnames)
-  local tagdate = options["date"] or os_date("%Y-%m-%d")
+  local tagdate = Opts.date or os_date("%Y-%m-%d")
   local tagname = nil
   if tagnames then
     tagname = tagnames[1]

--- a/l3build-unpack.lua
+++ b/l3build-unpack.lua
@@ -84,7 +84,7 @@ bundleunpack = bundleunpack or function(sourcedirs, sources)
           .. localdir .. (unpacksearch and os_pathsep or "") ..
         os_concat ..
         unpackexe .. " " .. unpackopts .. " " .. name
-          .. (options["quiet"] and (" > " .. os_null) or ""),
+          .. (Opts.quiet and (" > " .. os_null) or ""),
         "w"
       ):write(string.rep("y\n", 300)):close()
       if not success then

--- a/l3build-upload.lua
+++ b/l3build-upload.lua
@@ -70,7 +70,7 @@ local curl_debug = curl_debug or false -- to disable posting
 -- For now, this is undocumented.
 
 local ctanupload = ctanupload or "ask"
-if options["dry-run"] then
+if Opts["dry-run"] then
   ctanupload = false
 end
 -- if ctanupload is nil or false, only validation is attempted
@@ -89,13 +89,13 @@ function upload(tagnames)
   uploadconfig.pkg = uploadconfig.pkg or ctanpkg or nil
 
   -- Get data from command line if appropriate
-  if options["file"] then
-    local f = open(options["file"],"r")
+  if Opts.file then
+    local f = open(Opts.file,"r")
     uploadconfig.announcement = assert(f:read('*a'))
     close(f)
   end
-  uploadconfig.announcement = options["message"] or uploadconfig.announcement or file_contents(uploadconfig.announcement_file)
-  uploadconfig.email = options["email"] or uploadconfig.email
+  uploadconfig.announcement = Opts.message or uploadconfig.announcement or file_contents(uploadconfig.announcement_file)
+  uploadconfig.email = Opts.email or uploadconfig.email
 
 
   uploadconfig.note =   uploadconfig.note  or file_contents(uploadconfig.note_file)
@@ -117,7 +117,7 @@ function upload(tagnames)
     error("Missing zip file '" .. tostring(uploadfile) .. "'")
   end
 
-  ctan_post = construct_ctan_post(uploadfile,options["debug"])
+  ctan_post = construct_ctan_post(uploadfile,Opts.debug)
 
 
 -- curl file version
@@ -130,7 +130,7 @@ function upload(tagnames)
   ctan_post=curlexe .. " --config " .. curloptfile
   
 
-if options["debug"] then
+if Opts.debug then
     ctan_post = ctan_post ..  ' https://httpbin.org/post'
     fp_return = shell(ctan_post)
     print('\n\nCURL COMMAND:')


### PR DESCRIPTION
The lua code in the repository really needs some serious cleaning. Actually, it is rather hard to understand because quite everything is at the top level. Here are related problems

- some of the globals should be initialized before use
- some globals should turn to local because they are only used in a very limited scope
- `ctan_post` should not be at the same time global and local.
- some locals are useless shallow copies of globals

The first goal is to organize the code into more separated modules with a well defined dependency.
The second goal will be to have some regression tests.

In that pull request, l3build-arguments.lua is turned into a module. All inside references to global variables are turned into formal parameters references. Now the l3build.lua main controller creates the global variable named `Opts` to replace the former variable that was created inside l3build-arguments.lua as a side effect.

All options["foo"] have been renamed to Opts.foo for a much better legibility.