### PR TITLE
TARGET + NAMES

### DIFF
--- a/l3build-arguments.lua
+++ b/l3build-arguments.lua
@@ -175,17 +175,17 @@ local function argparse()
   -- Deal with this by assuming help and storing only apparently-valid
   -- input
   local a = arg[1]
-  result["target"] = "help"
+  result[l3b.TARGET] = "help"
   if a then
     -- No options are allowed in position 1, so filter those out
     if a == "--version" then
-      result["target"] = "version"
+      result[l3b.TARGET] = "version"
     elseif not match(a, "^%-") then
-      result["target"] = a
+      result[l3b.TARGET] = a
     end
   end
   -- Stop here if help or version is required
-  if result["target"] == "help" or result["target"] == "version" then
+  if result[l3b.TARGET] == "help" or result[l3b.TARGET] == "version" then
     return result
   end
   -- An auxiliary to grab all file names into a table
@@ -277,7 +277,7 @@ local function argparse()
     end
   end
   if next(names) then
-   result["names"] = names
+   result[l3b.NAMES] = names
   end
   return result
 end

--- a/l3build-aux.lua
+++ b/l3build-aux.lua
@@ -103,7 +103,7 @@ function call(modules, target, opts)
   opts = opts or options
   local cli_opts = ""
   for k,v in pairs(opts) do
-    if k ~= "names" and k ~= "target" then -- Special cases, TODO enhance the design to remove the need for this comment
+    if k ~= l3b.NAMES and k ~= l3b.TARGET then -- Special cases
       local t = option_list[k] or {}
       local value = ""
       if t["type"] == "string" then

--- a/l3build.lua
+++ b/l3build.lua
@@ -44,6 +44,13 @@ local select           = select
 local tonumber         = tonumber
 local exit             = os.exit
 
+-- global namespace and constants
+
+l3b = {
+  TARGET = {}, -- see https://www.lua.org/pil/13.4.3.html
+  NAMES  = {}, -- `--names` and `--target` are now available
+}
+
 -- l3build setup and functions
 kpse.set_program_name("kpsewhich")
 build_kpse_path = match(lookup("l3build.lua"),"(.*[/])")
@@ -53,6 +60,10 @@ end
 
 -- Minimal code to do basic checks
 build_require("arguments")
+-- `options` is available now
+local target = options[l3b.TARGET]
+local names  = options[l3b.NAMES]
+
 build_require("help")
 
 build_require("file-functions")
@@ -71,10 +82,10 @@ build_require("stdmain")
 
 -- This has to come after stdmain(),
 -- and that has to come after the functions are defined
-if options["target"] == "help" then
+if target == "help" then
   help()
   exit(0)
-elseif options["target"] == "version" then
+elseif target == "version" then
   version()
   exit(0)
 end
@@ -131,13 +142,13 @@ check_engines()
 
 -- When we have specific files to deal with, only use explicit configs
 -- (or just the std one)
-if options["names"] then
+if names then
   checkconfigs = options["config"] or {stdconfig}
 else
   checkconfigs = options["config"] or checkconfigs
 end
 
-if options["target"] == "check" then
+if target == "check" then
   if #checkconfigs > 1 then
     local errorlevel = 0
     local opts = options
@@ -159,7 +170,6 @@ if options["target"] == "check" then
         print("\n  Check failed with difference files")
         local testdir = testdir
         if config ~= "build" then
-          resultdir = resultdir .. "-" .. config
           testdir = testdir .. "-" .. config
         end
         for _,i in ipairs(filelist(testdir,"*" .. os_diffext)) do
@@ -176,7 +186,7 @@ if options["target"] == "check" then
 end
 if #checkconfigs == 1 and
    checkconfigs[1] ~= "build" and
-   (options["target"] == "check" or options["target"] == "save" or options["target"] == "clean") then
+   (target == "check" or target == "save" or target == "clean") then
    local config = "./" .. gsub(checkconfigs[1],".lua$","") .. ".lua"
    if fileexists(config) then
      local savedtestfiledir = testfiledir
@@ -194,4 +204,4 @@ if #checkconfigs == 1 and
 end
 
 -- Call the main function
-main(options["target"], options["names"])
+main(target, names)


### PR DESCRIPTION
the global options variable now follows the implicit rule that all its string named fields correspond to CLI options.
Formerly, options.names and options.target where used preventing to use `--target` and `--names`. This is no longer the case.

Also the line 162 was useless.