### PR TITLE
Alternate to PR #145 Document `options.target` and reserve keywords

### DIFF
--- a/l3build-arguments.lua
+++ b/l3build-arguments.lua
@@ -154,14 +154,14 @@ option_list =
         desc = "Print version information and exit",
         type = "boolean"
       },
-      target = 
-        {
-          reserved = true,
-        },
-      names = 
-        {
-          reserved = true,
-        },
+    target = 
+      {
+        reserved = true,
+      },
+    names = 
+      {
+        reserved = true,
+      },
   }
 
 -- This is done as a function (rather than do ... end) as it allows early

--- a/l3build-arguments.lua
+++ b/l3build-arguments.lua
@@ -153,7 +153,15 @@ option_list =
       {
         desc = "Print version information and exit",
         type = "boolean"
-      }
+      },
+      target = 
+        {
+          reserved = true,
+        },
+      names = 
+        {
+          reserved = true,
+        },
   }
 
 -- This is done as a function (rather than do ... end) as it allows early
@@ -165,10 +173,12 @@ local function argparse()
   local short_options = { }
   -- Turn long/short options into two lookup tables
   for k,v in pairs(option_list) do
-    if v["short"] then
-      short_options[v["short"]] = k
+    if not v.reserved then
+      if v["short"] then
+        short_options[v["short"]] = k
+      end
+      long_options[k] = k
     end
-    long_options[k] = k
   end
   local args = args
   -- arg[1] is a special case: must be a command or "-h"/"--help"

--- a/l3build-aux.lua
+++ b/l3build-aux.lua
@@ -103,8 +103,8 @@ function call(modules, target, opts)
   opts = opts or options
   local cli_opts = ""
   for k,v in pairs(opts) do
-    if k ~= "names" and k ~= "target" then -- Special cases, TODO enhance the design to remove the need for this comment
-      local t = option_list[k] or {}
+    local t = option_list[k] or {}
+    if not t.reserved then -- Special cases
       local value = ""
       if t["type"] == "string" then
         value = value .. "=" .. v

--- a/l3build-help.lua
+++ b/l3build-help.lua
@@ -39,16 +39,16 @@ end
 function help()
   local function setup_list(list)
     local longest = 0
+    local t = {}
     for k,v in pairs(list) do
-      if k:len() > longest then
-        longest = k:len()
+      if not v.reserved then
+        if k:len() > longest then
+          longest = k:len()
+        end
+        insert(t, k)
       end
     end
     -- Sort the options
-    local t = { }
-    for k,_ in pairs(list) do
-      insert(t, k)
-    end
     sort(t)
     return longest,t
   end

--- a/l3build.dtx
+++ b/l3build.dtx
@@ -1571,32 +1571,34 @@
 %
 % \begin{variable}{options}
 %   The |options| table holds the values passed to \pkg{l3build} at the
-%   command line. The possible entries in the table are given in the table
+%   command line including the target and the trailing list of names if any.
+%   The possible entries in this table are given in the table
 %   below.
 %   \begin{center}
 %   \begin{tabular}{ll}
 %     \toprule
 %     Entry & Type \\
 %     \midrule
-%       \var{config}        & Table   \\
-%       \var{date}          & String  \\
-%       \var{dirty}         & Boolean \\
-%       \var{dry-run}       & Boolean \\
-%       \var{email}         & String  \\
-%       \var{engine}        & Table   \\
-%       \var{epoch}         & String  \\
+%       \var{config}        & table   \\
+%       \var{date}          & string  \\
+%       \var{dirty}         & boolean \\
+%       \var{dry-run}       & boolean \\
+%       \var{email}         & string  \\
+%       \var{engine}        & table   \\
+%       \var{epoch}         & string  \\
 %       \var{file}          & string  \\
-%       \var{first}         & Boolean \\
-%       \var{force}         & Boolean \\
-%       \var{full}          & Boolean \\
-%       \var{halt-on-error} & Boolean \\
-%       \var{help}          & Boolean \\
+%       \var{first}         & boolean \\
+%       \var{force}         & boolean \\
+%       \var{full}          & boolean \\
+%       \var{halt-on-error} & boolean \\
+%       \var{help}          & boolean \\
 %       \var{message}       & string  \\
-%       \var{names}         & Table   \\
-%       \var{quiet}         & Boolean \\
-%       \var{rerun}         & Boolean \\
-%       \var{shuffle}       & Boolean \\
-%       \var{texmfhome}     & String  \\
+%       \var{names}         & table   \\
+%       \var{quiet}         & boolean \\
+%       \var{rerun}         & boolean \\
+%       \var{shuffle}       & boolean \\
+%       \var{target}        & string \\
+%       \var{texmfhome}     & string  \\
 %     \bottomrule
 %     \end{tabular}
 %   \end{center}


### PR DESCRIPTION
Document `options.target` in `l3build.dtx`.
The table description page 28 was not consistent is the use of capitals. As lua types are lowercase, all types are changed to lowercase.

Add a `reserved` tag to option definitions in `option_list` to reserve keywords.
Ideally, optional_list should be an implementation detail.

