### PR TITLE
Update l3build.dtx: return value must be 0

### DIFF
--- a/l3build.dtx
+++ b/l3build.dtx
@@ -1878,6 +1878,7 @@
 %     the |names| as an argument; this allows checking of the |name| data
 %     without impact on the main |func|.
 % \end{itemize}
+% The functions |func|, |bundle_func| and |pre| must return 0 on success.
 %
 % \subsection{Customising the manifest file}
 % \label{sec:manifest}


### PR DESCRIPTION
According to stdmain.
Obviously critical with |pre|
but problematic also with the others in case of a call.
