### PR TITLE
Solving issue#153

### DIFF
--- a/l3build-arguments.lua
+++ b/l3build-arguments.lua
@@ -158,7 +158,7 @@ option_list =
 
 -- This is done as a function (rather than do ... end) as it allows early
 -- termination (break)
-local function argparse()
+local function argparse(arg)
   local result = { }
   local names  = { }
   local long_options =  { }
@@ -282,8 +282,6 @@ local function argparse()
   return result
 end
 
-options = argparse()
-
 -- Sanity check
 function check_engines()
   if options["engine"] and not options["force"] then
@@ -305,3 +303,10 @@ function check_engines()
     end
   end
 end
+
+return {
+  _TYPE = "module",
+  _NAME = "arguments",
+  _VERSION = "2021/01/30",
+  parse = argparse,
+}

--- a/l3build.lua
+++ b/l3build.lua
@@ -53,6 +53,9 @@ end
 
 -- Minimal code to do basic checks
 build_require("arguments")
+local cli = build_require("arguments")
+options = cli.parse(arg)
+
 build_require("help")
 
 build_require("file-functions")


### PR DESCRIPTION
Solving issue 153 is interesting on its own.
As I envisage forthcoming development, as side effect it will have a positive impact on the main/stdmain business, the unit testing, the 101% backwards compatibility, at least.
Once a step has been validated, I'll add new material to be validated.
The "draft" will be converted to "review requested" when ready to merge to a new branch. Whether this new branch will later be merged into master or not should not be addressed now.

## Step 1
The problem is that defining a new CLI custom option will be made in `build.lua`. But `build.lua` is read only after the CLI arguments are parsed... So the first step is to allow the control on when arguments are parsed. For that l3build-arguments.lua is turned into a module.

## Step 2 (forthcoming)
Define an advanced mode to guarantee backwards compatibility.

## Step 3 (forthcoming)
Define a `declare_option` function

## Step 4 (forthcoming)
Test this function. Customizing the `build.lua` name will help.

If it is ok, let me know.