### PR TITLE
some error management abspath

### DIFF
--- a/l3build-file-functions.lua
+++ b/l3build-file-functions.lua
@@ -171,12 +171,16 @@ function normalize_path(path)
 end
 
 -- Return an absolute path from a relative one
+-- Due to chdir, path must exist and be accessible.
 function abspath(path)
   local oldpwd = currentdir()
-  chdir(path)
-  local result = currentdir()
-  chdir(oldpwd)
-  return escapepath(gsub(result, "\\", "/"))
+  local ok, msg = chdir(path)
+  if ok then
+    local result = currentdir()
+    chdir(oldpwd)
+    return escapepath(gsub(result, "\\", "/"))
+  end
+  return ok, msg
 end
 
 function escapepath(path)

--- a/l3build-file-functions.lua
+++ b/l3build-file-functions.lua
@@ -259,7 +259,7 @@ function fileexists(file)
     f:close()
     return true
   else
-    return false
+    return false -- also file exits and is not readable
   end
 end
 

--- a/l3build-file-functions.lua
+++ b/l3build-file-functions.lua
@@ -180,7 +180,7 @@ function abspath(path)
     chdir(oldpwd)
     return escapepath(gsub(result, "\\", "/"))
   end
-  return ok, msg
+  error(msg)
 end
 
 function escapepath(path)

--- a/l3build.dtx
+++ b/l3build.dtx
@@ -1616,7 +1616,7 @@
 %     |abspath(|\meta{target}|)|
 %   \end{syntax}
 %   Returns a string which gives the absolute location of the
-%   \meta{target} directory.
+%   \meta{target} directory. The \meta{target} directory must exist and be accessible.
 % \end{function}
 %
 % \begin{function}{dirname()}

--- a/l3build.dtx
+++ b/l3build.dtx
@@ -1616,7 +1616,7 @@
 %     |abspath(|\meta{target}|)|
 %   \end{syntax}
 %   Returns a string which gives the absolute location of the
-%   \meta{target} directory. The \meta{target} directory must exist and be accessible.
+%   \meta{target} directory.
 % \end{function}
 %
 % \begin{function}{dirname()}
@@ -1662,7 +1662,7 @@
 %   \begin{syntax}
 %     |fileexists(|\meta{file}|)|
 %   \end{syntax}
-%   Tests if the \meta{file} exists; returns a boolean value.
+%   Tests if the \meta{file} exists and is readable; returns a boolean value.
 % \end{function}
 %
 % \begin{function}{filelist()}


### PR DESCRIPTION
Due to the use of `lfs.chdir`, the return value is not the expected one
- when the target directory does not exist
- when permission were not sufficient
In both situations, lfs.currentdir() returns a path unrelated to the given argument.
These restrictions are added to the dtx.
Now the abspath returns what chdir returns in case of error.
