### PR TITLE
Drop loading build.lua direct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ this project uses date-based 'snapshot' version identifiers.
 - no longer expect LuaTeX line lengths to be off by a character for new
   LuaTeX versions
 
+### Removed
+- Support for use as `texlua build.lua <target>`
+
 ## [2020-06-04]
 
 ### Added

--- a/l3build-check.lua
+++ b/l3build-check.lua
@@ -85,7 +85,7 @@ function checkinit()
   return checkinit_hook()
 end
 
-checkinit_hook = checkinit_hook or function() return 0 end
+function checkinit_hook() return 0 end
 
 local function rewrite(source,result,processor,...)
   local file = assert(open(source,"rb"))
@@ -545,7 +545,7 @@ local function normalize_pdf(content)
       stream = true
       stream_content = "stream" .. os_newline
     elseif not match(line, "^ *$") and
-      not match(line,"^%%%%Invocation") and 
+      not match(line,"^%%%%Invocation") and
       not match(line,"^%%%%%+") then
       line = gsub(line,"%/ID( ?)%[<[^>]+><[^>]+>]","/ID%1[<ID-STRING><ID-STRING>]")
       new_content = new_content .. line .. os_newline
@@ -824,7 +824,7 @@ function runtest(name, engine, hide, ext, test_type, breakout)
 end
 
 -- A hook to allow additional tasks to run for the tests
-runtest_tasks = runtest_tasks or function(name,run)
+function runtest_tasks(name,run)
   return ""
 end
 

--- a/l3build-manifest-setup.lua
+++ b/l3build-manifest-setup.lua
@@ -248,7 +248,7 @@ It is automatically generated with `texlua build.lua manifest`.
 
 end
 
-functiom manifest_write_subheading(filehandle,heading,description)
+function manifest_write_subheading(filehandle,heading,description)
 
   filehandle:write("\n\n## " .. heading .. "\n\n")
 

--- a/l3build-manifest-setup.lua
+++ b/l3build-manifest-setup.lua
@@ -54,7 +54,7 @@ for those people who are interested.
 --]]
 
 
-manifest_setup = manifest_setup or function()
+function manifest_setup()
   local groups = {
     {
        subheading = "Repository manifest",
@@ -238,7 +238,7 @@ end
       ---------------
 --]]
 
-manifest_write_opening = manifest_write_opening or function(filehandle)
+function manifest_write_opening(filehandle)
 
   filehandle:write("# Manifest for " .. module .. "\n\n")
   filehandle:write([[
@@ -248,7 +248,7 @@ It is automatically generated with `texlua build.lua manifest`.
 
 end
 
-manifest_write_subheading = manifest_write_subheading or function(filehandle,heading,description)
+functiom manifest_write_subheading(filehandle,heading,description)
 
   filehandle:write("\n\n## " .. heading .. "\n\n")
 
@@ -258,7 +258,7 @@ manifest_write_subheading = manifest_write_subheading or function(filehandle,hea
 
 end
 
-manifest_write_group_heading = manifest_write_group_heading or function (filehandle,heading,description)
+function manifest_write_group_heading(filehandle,heading,description)
 
   filehandle:write("\n### " .. heading .. "\n\n")
 
@@ -268,7 +268,7 @@ manifest_write_group_heading = manifest_write_group_heading or function (filehan
 
 end
 
-manifest_write_group_file = manifest_write_group_file or function(filehandle,filename,param)
+function manifest_write_group_file(filehandle,filename,param)
   --[[
         filehandle        : write file object
         filename          : the count of the filename to be written
@@ -294,7 +294,7 @@ manifest_write_group_file = manifest_write_group_file or function(filehandle,fil
 
 end
 
-manifest_write_group_file_descr = manifest_write_group_file_descr or function(filehandle,filename,descr,param)
+function manifest_write_group_file_descr(filehandle,filename,descr,param)
   --[[
         filehandle        : write file object
         filename          : the name of the file to write
@@ -324,7 +324,7 @@ end
       -------------------------------------------
 --]]
 
-manifest_extract_filedesc = manifest_extract_filedesc or function(filehandle)
+function manifest_extract_filedesc(filehandle)
 
   -- no-op by default; two examples below
 

--- a/l3build-manifest.lua
+++ b/l3build-manifest.lua
@@ -33,7 +33,7 @@ for those people who are interested.
       `l3build-manifest-setup.lua`.
 --]]
 
-manifest = manifest or function()
+function manifest()
 
   -- build list of ctan files
   ctanfiles = {}
@@ -277,4 +277,3 @@ manifest_write_group = function(f,entry)
   end
 
 end
-

--- a/l3build-stdmain.lua
+++ b/l3build-stdmain.lua
@@ -151,7 +151,7 @@ target_list =
 -- The overall main function
 --
 
-function stdmain(target,names)
+function main(target,names)
   -- Deal with unknown targets up-front
   if not target_list[target] then
     help()

--- a/l3build-tagging.lua
+++ b/l3build-tagging.lua
@@ -28,7 +28,7 @@ local os_date = os.date
 local match   = string.match
 local gsub    = string.gsub
 
-update_tag = update_tag or function(filename,content,tagname,tagdate)
+function update_tag(filename,content,tagname,tagdate)
   return content
 end
 
@@ -81,4 +81,3 @@ function tag(tagnames)
   end
   return tag_hook(tagname,tagdate)
 end
-

--- a/l3build-typesetting.lua
+++ b/l3build-typesetting.lua
@@ -146,7 +146,7 @@ local function typesetpdf(file,dir)
   return cp(pdfname,dir,docfiledir)
 end
 
-typeset = typeset or function(file,dir,exe)
+function typeset(file,dir,exe)
   dir = dir or "."
   local errorlevel = tex(file,dir,exe)
   if errorlevel ~= 0 then
@@ -168,7 +168,7 @@ typeset = typeset or function(file,dir,exe)
 end
 
 -- A hook to allow additional typesetting of demos
-typeset_demo_tasks = typeset_demo_tasks or function()
+function typeset_demo_tasks()
   return 0
 end
 
@@ -198,7 +198,7 @@ local function docinit()
   return docinit_hook()
 end
 
-docinit_hook = docinit_hook or function() return 0 end
+function docinit_hook() return 0 end
 
 -- Typeset all required documents
 -- Uses a set of dedicated auxiliaries that need to be available to others
@@ -240,4 +240,3 @@ function doc(files)
   end
   return 0
 end
-

--- a/l3build-unpack.lua
+++ b/l3build-unpack.lua
@@ -44,7 +44,7 @@ end
 
 -- Split off from the main unpack so it can be used on a bundle and not
 -- leave only one modules files
-bundleunpack = bundleunpack or function(sourcedirs, sources)
+function bundleunpack(sourcedirs, sources)
   local errorlevel = mkdir(localdir)
   if errorlevel ~=0 then
     return errorlevel

--- a/l3build.dtx
+++ b/l3build.dtx
@@ -657,28 +657,6 @@
 % A collection of full examples (source files in various layouts) are available
 % at \url{https://github.com/latex3/l3build/tree/master/examples}.
 %
-% \subsection{Backwards compatibility}
-%
-% Earlier releases of \pkg{l3build} required that the last line of
-% \texttt{build.lua} ran the main script, \emph{i.e.}~that \texttt{build.lua}
-% was what the user called rather than \texttt{l3build.lua}. To allow scripts
-% to support both forms \emph{for the transition}, a simple test may be
-% included as showing in Figure~\ref{fig:build-compat}.
-% \begin{figure}
-%   \begin{lstlisting}[frame=single,language={[5.2]Lua},gobble = 6]
-%     if not release_date then
-%       dofile(kpse.lookup("l3build.lua"))
-%     end
-%   \end{lstlisting}
-% \caption{Final lines for a \texttt{build.lua} script usable with both older
-%   and newer releases of \pkg{l3build}.}
-% \label{fig:build-compat}
-% \end{figure}
-%
-% Note that in time support for loading \pkg{l3build} by calling the
-% \texttt{build.lua} script \emph{may} be removed: the recommended approach for
-% new scripts is to run \texttt{l3build}.
-%
 % \subsection{Variables}
 %
 % This section lists all variables defined in the |l3build.lua| script that are available for customisation.

--- a/l3build.lua
+++ b/l3build.lua
@@ -79,9 +79,6 @@ elseif options["target"] == "version" then
   exit(0)
 end
 
--- Allow main function to be disabled 'higher up'
-main = main or stdmain
-
 -- Look for some configuration details
 if fileexists("build.lua") then
   dofile("build.lua")

--- a/l3build.lua
+++ b/l3build.lua
@@ -82,15 +82,12 @@ end
 -- Allow main function to be disabled 'higher up'
 main = main or stdmain
 
--- Load configuration file if running as a script
-if match(arg[0], "l3build$") or match(arg[0], "l3build%.lua$") then
-  -- Look for some configuration details
-  if fileexists("build.lua") then
-    dofile("build.lua")
-  else
-    print("Error: Cannot find configuration build.lua")
-    exit(1)
-  end
+-- Look for some configuration details
+if fileexists("build.lua") then
+  dofile("build.lua")
+else
+  print("Error: Cannot find configuration build.lua")
+  exit(1)
 end
 
 -- Load standard settings for variables:


### PR DESCRIPTION
As discussed, we likely should drop this at this stage: it's older and rather awkward to support across-the-board.