### PR TITLE
Use LPEG to convert glob expression into pattern

### DIFF
--- a/l3build-file-functions.lua
+++ b/l3build-file-functions.lua
@@ -49,75 +49,22 @@ local gsub             = string.gsub
 
 local insert           = table.insert
 
--- Convert a file glob into a pattern for use by e.g. string.gub
--- Based on https://github.com/davidm/lua-glob-pattern
--- Simplified substantially: "[...]" syntax not supported as is not
--- required by the file patterns used by the team. Also note style
--- changes to match coding approach in rest of this file.
---
--- License for original globtopattern
---[[
-
-   (c) 2008-2011 David Manura.  Licensed under the same terms as Lua (MIT).
-
-  Permission is hereby granted, free of charge, to any person obtaining a copy
-  of this software and associated documentation files (the "Software"), to deal
-  in the Software without restriction, including without limitation the rights
-  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-  copies of the Software, and to permit persons to whom the Software is
-  furnished to do so, subject to the following conditions:
-
-  The above copyright notice and this permission notice shall be included in
-  all copies or substantial portions of the Software.
-
-  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
-  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-  THE SOFTWARE.
-  (end license)
-
---]]
-function glob_to_pattern(glob)
-
-  local pattern = "^" -- pattern being built
-  local i = 0 -- index in glob
-  local char -- char at index i in glob
-
-  -- escape pattern char
-  local function escape(char)
-    return match(char, "^%w$") and char or "%" .. char
-  end
-
-  -- Convert tokens.
-  while true do
-    i = i + 1
-    char = sub(glob, i, i)
-    if char == "" then
-      pattern = pattern .. "$"
-      break
-    elseif char == "?" then
-      pattern = pattern .. "."
-    elseif char == "*" then
-      pattern = pattern .. ".*"
-    elseif char == "[" then
-      -- Ignored
-      print("[...] syntax not supported in globs!")
-    elseif char == "\\" then
-      i = i + 1
-      char = sub(glob, i, i)
-      if char == "" then
-        pattern = pattern .. "\\$"
-        break
-      end
-      pattern = pattern .. escape(char)
-    else
-      pattern = pattern .. escape(char)
-    end
-  end
-  return pattern
+--- Convert a file glob into a pattern for use by e.g. string.gub
+do
+   local l = lpeg or require'lpeg'
+   local escaped_char = l.Cc'%' * l.S'^$()%.[]*+-?' + 1
+   local to_pattern = l.Cs(l.Cc'^' * (
+        l.Cg('?' * l.Cc'.'
+           + '*' * l.Cc'.*'
+           + '\\' * (-1 + l.C(escaped_char)))
+      + l.P'[' / function()
+            print("[...] syntax not supported in globs!")
+            return ''
+         end
+      + escaped_char)^0 * l.Cc'$')
+   function glob_to_pattern(glob)
+      return to_pattern:match(glob)
+   end
 end
 
 -- Detect the operating system in use


### PR DESCRIPTION
Reimplement `glob_to_pattern` using LPEG to make it more extensible and (IMO) more readable.

The resulting pattern is still a Lua pattern and not a LPEG parser. This ensures that the function keeps compatibility and it is faster for typical file globs.