### PR TITLE
issue#161: Solved

### DIFF
--- a/l3build-check.lua
+++ b/l3build-check.lua
@@ -63,23 +63,23 @@ function checkinit()
   -- Copy dependencies to the test directory itself: this makes the paths
   -- a lot easier to manage, and is important for dealing with the log and
   -- with file input/output tests
-  for _,i in ipairs(filelist(localdir)) do
-    cp(i, localdir, testdir)
+  for _,n in ipairs(filelist(localdir)) do
+    copy(n, localdir, testdir)
   end
   bundleunpack({sourcefiledir, testfiledir})
-  for _,i in ipairs(installfiles) do
-    cp(i, unpackdir, testdir)
+  for _,g in ipairs(installfiles) do
+    cp(g, unpackdir, testdir)
   end
-  for _,i in ipairs(checkfiles) do
-    cp(i, unpackdir, testdir)
+  for _,g in ipairs(checkfiles) do
+    cp(g, unpackdir, testdir)
   end
   if direxists(testsuppdir) then
-    for _,i in ipairs(filelist(testsuppdir)) do
-      cp(i, testsuppdir, testdir)
+    for _,n in ipairs(filelist(testsuppdir)) do
+      copy(n, testsuppdir, testdir)
     end
   end
-  for _,i in ipairs(checksuppfiles) do
-    cp(i, supportdir, testdir)
+  for _,g in ipairs(checksuppfiles) do
+    cp(g, supportdir, testdir)
   end
   execute(os_ascii .. ">" .. testdir .. "/ascii.tcx")
   return checkinit_hook()
@@ -625,7 +625,7 @@ function setup_check(name, engine)
     -- Install comparison files found
     for _,v in pairs({tlgfile, tpffile}) do
       if v then
-        cp(
+        copy(
           match(v, ".*/(.*)"),
           match(v, "(.*)/.*"),
           testdir
@@ -693,10 +693,10 @@ end
 -- both creating and verifying
 function runtest(name, engine, hide, ext, pdfmode, breakout)
   local lvtfile = name .. (ext or lvtext)
-  cp(lvtfile, fileexists(testfiledir .. "/" .. lvtfile)
+  copy(lvtfile, fileexists(testfiledir .. "/" .. lvtfile)
     and testfiledir or unpackdir, testdir)
   local checkopts = checkopts
-  local engine = engine or stdengine
+  engine = engine or stdengine
   local binary = engine
   local format = gsub(engine,"tex$",checkformat)
   -- Special binary/format combos
@@ -797,7 +797,7 @@ function runtest(name, engine, hide, ext, pdfmode, breakout)
     dvitopdf(name, testdir, engine, hide)
   end
   if pdfmode then
-    cp(name .. pdfext,testdir,resultdir)
+    copy(name .. pdfext,testdir,resultdir)
     ren(resultdir,name .. pdfext,name .. "." .. engine .. pdfext)
     rewrite(pdffile,npffile,normalize_pdf)
   else
@@ -1001,7 +1001,7 @@ function save(names)
           print("Creating and copying " .. out_file)
           runtest(name,engine,false,test_ext,pdfmode)
           ren(testdir,gen_file,out_file)
-          cp(out_file,testdir,testfiledir)
+          copy(out_file,testdir,testfiledir)
           if fileexists(unpackdir .. "/" .. out_file) then
             print("Saved " .. out_ext
               .. " file overrides unpacked version of the same name")

--- a/l3build-ctan.lua
+++ b/l3build-ctan.lua
@@ -33,17 +33,17 @@ function copyctan()
   mkdir(ctandir .. "/" .. ctanpkg)
   local function copyfiles(files,source)
     if source == currentdir or flatten then
-      for _,filetype in pairs(files) do
-        cp(filetype,source,ctandir .. "/" .. ctanpkg)
+      for _,g_filetype in pairs(files) do
+        cp(g_filetype,source,ctandir .. "/" .. ctanpkg)
       end
     else
-      for _,filetype in pairs(files) do
-        for file,_ in pairs(tree(source,filetype)) do
+      for _,g_filetype in pairs(files) do
+        for file,_ in pairs(tree(source,g_filetype)) do
           local path = splitpath(file)
           local ctantarget = ctandir .. "/" .. ctanpkg .. "/"
             .. source .. "/" .. path
           mkdir(ctantarget)
-          cp(file,source,ctantarget)
+          copy(file,source,ctantarget)
         end
       end
     end
@@ -53,8 +53,8 @@ function copyctan()
     copyfiles(tab,docfiledir)
   end
   copyfiles(sourcefiles,sourcefiledir)
-  for _,file in pairs(textfiles) do
-    cp(file, textfiledir, ctandir .. "/" .. ctanpkg)
+  for _,g in pairs(textfiles) do
+    cp(g, textfiledir, ctandir .. "/" .. ctanpkg)
   end
 end
 
@@ -126,10 +126,10 @@ function ctan()
     return errorlevel
   end
   if errorlevel == 0 then
-    for _,i in ipairs(textfiles) do
+    for _,g in ipairs(textfiles) do
       for _,j in pairs({unpackdir, textfiledir}) do
-        cp(i, j, ctandir .. "/" .. ctanpkg)
-        cp(i, j, tdsdir .. "/doc/" .. tdsroot .. "/" .. bundle)
+        cp(g, j, ctandir .. "/" .. ctanpkg)
+        cp(g, j, tdsdir .. "/doc/" .. tdsroot .. "/" .. bundle)
       end
     end
     -- Rename README if necessary
@@ -145,10 +145,10 @@ function ctan()
     end
     dirzip(tdsdir, ctanpkg .. ".tds")
     if packtdszip then
-      cp(ctanpkg .. ".tds.zip", tdsdir, ctandir)
+      copy(ctanpkg .. ".tds.zip", tdsdir, ctandir)
     end
     dirzip(ctandir, ctanzip)
-    cp(ctanzip .. ".zip", ctandir, currentdir)
+    copy(ctanzip .. ".zip", ctandir, currentdir)
   else
     print("\n====================")
     print("Typesetting failed, zip stage skipped!")

--- a/l3build-file-functions.lua
+++ b/l3build-file-functions.lua
@@ -213,27 +213,36 @@ end
 
 -- Copy files 'quietly'
 function cp(glob, source, dest)
-  local errorlevel
   for i,_ in pairs(tree(source, glob)) do
-    local source = source .. "/" .. i
-    if os_type == "windows" then
-      if attributes(source)["mode"] == "directory" then
-        errorlevel = execute(
-          'xcopy /y /e /i "' .. unix_to_win(source) .. '" "'
-             .. unix_to_win(dest .. '/' .. i) .. '" > nul'
-        )
-      else
-        errorlevel = execute(
-          'xcopy /y "' .. unix_to_win(source) .. '" "'
-             .. unix_to_win(dest .. '/') .. '" > nul'
-        )
-      end
-    else
-      errorlevel = execute("cp -RLf '" .. source .. "' '" .. dest .. "'")
-    end
+    local errorlevel = copy(i, source, dest)
     if errorlevel ~=0 then
       return errorlevel
     end
+  end
+  return 0
+end
+
+-- Copy one file 'quietly'
+function copy(name, source, dest)
+  local errorlevel
+  source = source .. "/" .. name
+  if os_type == "windows" then
+    if attributes(source)["mode"] == "directory" then
+      errorlevel = execute(
+        'xcopy /y /e /i "' .. unix_to_win(source) .. '" "'
+           .. unix_to_win(dest .. '/' .. name) .. '" > nul'
+      )
+    else
+      errorlevel = execute(
+        'xcopy /y "' .. unix_to_win(source) .. '" "'
+           .. unix_to_win(dest .. '/') .. '" > nul'
+      )
+    end
+  else
+    errorlevel = execute("cp -RLf '" .. source .. "' '" .. dest .. "'")
+  end
+  if errorlevel ~=0 then
+    return errorlevel
   end
   return 0
 end

--- a/l3build-install.lua
+++ b/l3build-install.lua
@@ -263,7 +263,7 @@ function install_files(target,full,dry_run)
           -- Man files should have a single-digit extension: the type
           local installdir = target .. "/doc/man/man"  .. match(file,".$")
           errorlevel = errorlevel + mkdir(installdir)
-          errorlevel = errorlevel + cp(file,docfiledir,installdir)
+          errorlevel = errorlevel + copy(file,docfiledir,installdir)
         end
       end
     end
@@ -286,7 +286,7 @@ function install_files(target,full,dry_run)
   -- Files are all copied in one shot: this ensures that cleandir()
   -- can't be an issue even if there are complex set-ups
   for _,v in ipairs(installmap) do
-    errorlevel = cp(v.file,v.source,v.dest)
+    errorlevel = copy(v.file,v.source,v.dest)
     if errorlevel ~= 0  then return errorlevel end
   end 
   

--- a/l3build-typesetting.lua
+++ b/l3build-typesetting.lua
@@ -143,7 +143,7 @@ local function typesetpdf(file,dir)
   end
   pdfname = name .. pdfext
   rm(docfiledir,pdfname)
-  return cp(pdfname,dir,docfiledir)
+  return copy(pdfname,dir,docfiledir)
 end
 
 typeset = typeset or function(file,dir,exe)
@@ -178,15 +178,15 @@ local function docinit()
   for _,filetype in pairs(
       {bibfiles, docfiles, typesetfiles, typesetdemofiles}
     ) do
-    for _,file in pairs(filetype) do
-      cp(file, docfiledir, typesetdir)
+    for _,g in pairs(filetype) do
+      cp(g, docfiledir, typesetdir)
     end
   end
-  for _,file in pairs(sourcefiles) do
-    cp(file, sourcefiledir, typesetdir)
+  for _,g in pairs(sourcefiles) do
+    cp(g, sourcefiledir, typesetdir)
   end
-  for _,file in pairs(typesetsuppfiles) do
-    cp(file, supportdir, typesetdir)
+  for _,g in pairs(typesetsuppfiles) do
+    cp(g, supportdir, typesetdir)
   end
   dep_install(typesetdeps)
   unpack({sourcefiles, typesetsourcefiles}, {sourcefiledir, docfiledir})

--- a/l3build-unpack.lua
+++ b/l3build-unpack.lua
@@ -35,8 +35,8 @@ function unpack(sources, sourcedirs)
   if errorlevel ~= 0 then
     return errorlevel
   end
-  for _,i in ipairs(installfiles) do
-    errorlevel = cp(i, unpackdir, localdir)
+  for _,g in ipairs(installfiles) do
+    errorlevel = cp(g, unpackdir, localdir)
     if errorlevel ~= 0 then
       return errorlevel
     end
@@ -57,16 +57,16 @@ bundleunpack = bundleunpack or function(sourcedirs, sources)
   end
   for _,i in ipairs(sourcedirs or {sourcefiledir}) do
     for _,j in ipairs(sources or {sourcefiles}) do
-      for _,k in ipairs(j) do
-        errorlevel = cp(k, i, unpackdir)
+      for _,g in ipairs(j) do
+        errorlevel = cp(g, i, unpackdir)
         if errorlevel ~=0 then
           return errorlevel
         end
       end
     end
   end
-  for _,i in ipairs(unpacksuppfiles) do
-    errorlevel = cp(i, supportdir, localdir)
+  for _,g in ipairs(unpacksuppfiles) do
+    errorlevel = cp(g, supportdir, localdir)
     if errorlevel ~=0 then
       return errorlevel
     end

--- a/l3build.dtx
+++ b/l3build.dtx
@@ -1643,6 +1643,14 @@
 %   Removes any content within the \meta{dir}; returns an error level.
 % \end{function}
 %
+% \begin{function}{copy()}
+%   \begin{syntax}
+%     |copy(|\meta{item}, \meta{source}, \meta{destination}|)|
+%   \end{syntax}
+%   Copies \meta{item} from the \meta{source} directory
+%   to the \meta{destination}; returns an error level.
+% \end{function}
+%
 % \begin{function}{cp()}
 %   \begin{syntax}
 %     |cp(|\meta{glob}, \meta{source}, \meta{destination}|)|


### PR DESCRIPTION
1) file-functions:
a) new `copy` function for only one item
b) `cp` now uses `copy`
2) `copy` is documented in the `dtx`
3) For the other files, every `cp` has been revisited
a) replaced by `copy` for item names
b) var names are replaced to include a `g` when it is a glob to avoid confusion.