### PR TITLE
no hidden files in filelist by default

### DIFF
--- a/l3build-file-functions.lua
+++ b/l3build-file-functions.lua
@@ -278,9 +278,14 @@ function filelist(path, glob)
           insert(files, entry)
         end
       else
-        if not match(entry, "^%.") then
-          insert(files, entry)
-        end
+        insert(files, entry)
+      end
+    end
+    local t = files
+    files = {}
+    for _, entry in pairs(t) do
+      if not match(entry, "^%.") then
+        insert(files, entry)
       end
     end
   end

--- a/l3build-file-functions.lua
+++ b/l3build-file-functions.lua
@@ -267,18 +267,18 @@ end
 -- if absent
 function filelist(path, glob)
   local files = { }
-  local pattern
-  if glob then
-    pattern = glob_to_pattern(glob)
-  end
   if direxists(path) then
+    local pattern
+    if glob then
+      pattern = glob_to_pattern(glob)
+    end
     for entry in lfs_dir(path) do
       if pattern then
         if match(entry, pattern) then
           insert(files, entry)
         end
       else
-        if entry ~= "." and entry ~= ".." then
+        if not match(entry, "^%.") then
           insert(files, entry)
         end
       end

--- a/l3build-file-functions.lua
+++ b/l3build-file-functions.lua
@@ -281,11 +281,15 @@ function filelist(path, glob)
         insert(files, entry)
       end
     end
-    local t = files
-    files = {}
-    for _, entry in pairs(t) do
-      if not match(entry, "^%.") then
-        insert(files, entry)
+    if not pattern
+    or pattern:gsub("%%", ""):gsub("%*", ""):match("%*")
+    then
+      local t = files
+      files = {}
+      for _, entry in pairs(t) do
+        if not match(entry, "^%.") then
+          insert(files, entry)
+        end
       end
     end
   end

--- a/l3build-file-functions.lua
+++ b/l3build-file-functions.lua
@@ -266,6 +266,7 @@ end
 -- Generate a table containing all file names of the given glob or all files
 -- if absent
 function filelist(path, glob)
+  print("************************************* FILELIST")
   local files = { }
   if direxists(path) then
     local pattern
@@ -281,13 +282,16 @@ function filelist(path, glob)
         insert(files, entry)
       end
     end
-    if not pattern
-    or pattern:gsub("%%", ""):gsub("%*", ""):match("%*")
-    then
+    if not pattern or not match(pattern, "^%^%%%.") then
       local t = files
       files = {}
-      for _, entry in pairs(t) do
-        if not match(entry, "^%.") then
+      for _, entry in ipairs(t) do
+        if match(entry, "^%.") then
+          print("**** ignored " .. entry)
+          if entry == ".tex" then
+            print(".tex is ignored during " .. options.target)
+          end
+        else
           insert(files, entry)
         end
       end


### PR DESCRIPTION
Move the declaration of pattern inside its scope
Exclude dot names from default listing

there is often a `.DS_Store` in a directory on OSX, maybe a `.git` too