### PR TITLE
typo i instead of name

### DIFF
--- a/l3build-check.lua
+++ b/l3build-check.lua
@@ -874,7 +874,7 @@ function check(names)
         end
         for _,name in pairs(filelist(unpackdir, glob .. lvtext)) do
           if fileexists(testfiledir .. "/" .. name) then
-            print("Duplicate test file: " .. i)
+            print("Duplicate test file: " .. name)
             return 1
           end
           addname(name)


### PR DESCRIPTION
Using a possibly undefined global variable `i` instead of the local one `name`