### PR TITLE
Refactor set epoch cmd, clean locals, bug fix

### DIFF
--- a/l3build-aux.lua
+++ b/l3build-aux.lua
@@ -60,19 +60,22 @@ function normalise_epoch(epoch)
   end
 end
 
----CLI command to set the epoch, will be run while checking or typesetting
+---Returns the CLI command (ending with `os_concat`) to set the epoch
+---when forcecheckepoch is true, a void string otherwise.
+---Will be run while checking or typesetting
 ---@param epoch string
 ---@return string
 ---@see check, typesetting
 ---@usage private?
 function set_epoch_cmd(epoch)
-  return
+  return forcecheckepoch and (
     os_setenv .. " SOURCE_DATE_EPOCH=" .. epoch
       .. os_concat ..
     os_setenv .. " SOURCE_DATE_EPOCH_TEX_PRIMITIVES=1"
       .. os_concat ..
     os_setenv .. " FORCE_SOURCE_DATE=1"
       .. os_concat
+  ) or ""
 end
 
 ---Returns the script name depending on the calling sequence.

--- a/l3build-check.lua
+++ b/l3build-check.lua
@@ -435,7 +435,7 @@ local function normalize_lua_log(content,luatex)
       end
     end
     -- Look for another form of \discretionary, replacing a "-"
-    pattern = "^%.+\\discretionary replacing *$"
+    local pattern = "^%.+\\discretionary replacing *$"
     if match(line, pattern) then
       return "", line
     else

--- a/l3build-check.lua
+++ b/l3build-check.lua
@@ -806,18 +806,12 @@ function runtest(name, engine, hide, ext, pdfmode, breakout)
   -- Store secondary files for this engine
   for _,filetype in pairs(auxfiles) do
     for _,file in pairs(filelist(testdir, filetype)) do
-      if match(file,"^" .. name .. ".[^.]+$") then
-        local e7n = match(file, "%.[^.]+$")
-        if e7n ~= lvtext and
-           e7n ~= tlgext and
-           e7n ~= lveext and
-           e7n ~= logext then
-           local newname = gsub(file,"(%.[^.]+)$","." .. engine .. "%1")
-           if fileexists(testdir .. "/" .. newname) then
-             rm(testdir,newname)
-           end
-           ren(testdir,file,newname)
+      if match(file,"^" .. name .. "%.[^.]+$") then
+        local newname = gsub(file,"(%.[^.]+)$","." .. engine .. "%1")
+        if fileexists(testdir .. "/" .. newname) then
+          rmfile(testdir,newname)
         end
+        ren(testdir,file,newname)
       end
     end
   end

--- a/l3build-check.lua
+++ b/l3build-check.lua
@@ -698,7 +698,7 @@ function runtest(name, engine, hide, ext, pdfmode, breakout)
   local checkopts = checkopts
   engine = engine or stdengine
   local binary = engine
-  format = gsub(engine,"tex$",checkformat)
+  local format_a = gsub(engine,"tex$",checkformat)
   -- Special binary/format combos
   if specialformats[checkformat] and next(specialformats[checkformat]) then
     local t = specialformats[checkformat]
@@ -706,12 +706,12 @@ function runtest(name, engine, hide, ext, pdfmode, breakout)
     if t_ngn and next(t_ngn) then
       binary    = t_ngn.binary  or binary
       checkopts = t_ngn.options or checkopts
-      format    = t_ngn.format  or format
+      format_a    = t_ngn.format  or format_a
     end
   end
   -- Finalise format string
-  if format ~= "" then
-    format = " --fmt=" .. format
+  if format_a ~= "" then
+    format_a = " --fmt=" .. format_a
   end
   -- Special casing for XeTeX engine
   if match(engine, "xetex") and not pdfmode then
@@ -768,7 +768,7 @@ function runtest(name, engine, hide, ext, pdfmode, breakout)
       -- Ensure lines are of a known length
       os_setenv .. " max_print_line=" .. maxprintline
         .. os_concat ..
-      binary .. format
+      binary .. format_a
         .. " " .. asciiopt .. " " .. checkopts
         .. setup(lvtfile)
         .. (hide and (" > " .. os_null) or "")

--- a/l3build-check.lua
+++ b/l3build-check.lua
@@ -34,7 +34,7 @@ local luatex_version   = status.luatex_version
 
 local len              = string.len
 local char             = string.char
-local frmt             = string.format
+local str_format       = string.format
 local gmatch           = string.gmatch
 local gsub             = string.gsub
 local match            = string.match
@@ -269,7 +269,7 @@ local function normalize_log(content,engine,errlevels)
     -- tidy up to match pdfTeX if an ASCII engine is in use
     if next(asciiengines) then
       for i = 128, 255 do
-        line = gsub(line, utf8_char(i), "^^" .. frmt("%02x", i))
+        line = gsub(line, utf8_char(i), "^^" .. str_format("%02x", i))
       end
     end
     return line, lastline
@@ -345,7 +345,7 @@ local function normalize_lua_log(content,luatex)
         l,
         m .. " (%-?)%d+%.%d+",
         m .. " %1"
-          .. frmt(
+          .. str_format(
             "%.3f",
             match(line, m .. " %-?(%d+%.%d+)") or 0
           )
@@ -714,13 +714,13 @@ function runtest(name, engine, hide, ext, test_type, breakout)
   local binary = engine
   local format = gsub(engine,"tex$",checkformat)
   -- Special binary/format combos
-  if specialformats[checkformat] and next(specialformats[checkformat]) then
-    local t = specialformats[checkformat]
-    local t_ngn = t[engine]
-    if t_ngn then
-      binary    = t_ngn.binary  or binary
-      format    = t_ngn.format  or format
-      checkopts = t_ngn.options or checkopts
+  local special_check = specialformats[checkformat]
+  if special_check and next(special_check) then
+    local engine_info = special_check[engine]
+    if engine_info then
+      binary    = engine_info.binary  or binary
+      format    = engine_info.format  or format
+      checkopts = engine_info.options or checkopts
     end
   end
   -- Finalise format string
@@ -933,10 +933,8 @@ function check(names)
     end
     -- Actually run the tests
     print("Running checks on")
-    local i = 0
-    for _,name in ipairs(names) do
-      i = i + 1
-      print("  " .. name .. " (" ..  i.. "/" .. #names ..")")
+    for i, name in ipairs(names) do
+      print("  " .. name .. " (" ..  i .. "/" .. #names ..")")
       local errlevel = runcheck(name, hide)
       -- Return value must be 1 not errlevel
       if errlevel ~= 0 then
@@ -1015,7 +1013,7 @@ function save(names)
       return 1
     end
     for _,engine in pairs(engines) do
-      local testengine = ((engine == stdengine and "") or ("." .. engine))
+      local testengine = engine == stdengine and "" or ("." .. engine)
       local out_file = name .. testengine .. test_type.reference
       local gen_file = name .. "." .. engine .. test_type.generated
       print("Creating and copying " .. out_file)

--- a/l3build-check.lua
+++ b/l3build-check.lua
@@ -34,7 +34,7 @@ local luatex_version   = status.luatex_version
 
 local len              = string.len
 local char             = string.char
-local format           = string.format
+local frmt             = string.format
 local gmatch           = string.gmatch
 local gsub             = string.gsub
 local match            = string.match
@@ -269,7 +269,7 @@ local function normalize_log(content,engine,errlevels)
     -- tidy up to match pdfTeX if an ASCII engine is in use
     if next(asciiengines) then
       for i = 128, 255 do
-        line = gsub(line, utf8_char(i), "^^" .. format("%02x", i))
+        line = gsub(line, utf8_char(i), "^^" .. frmt("%02x", i))
       end
     end
     return line, lastline
@@ -345,7 +345,7 @@ local function normalize_lua_log(content,luatex)
         l,
         m .. " (%-?)%d+%.%d+",
         m .. " %1"
-          .. format(
+          .. frmt(
             "%.3f",
             match(line, m .. " %-?(%d+%.%d+)") or 0
           )
@@ -712,20 +712,20 @@ function runtest(name, engine, hide, ext, test_type, breakout)
   local checkopts = checkopts
   engine = engine or stdengine
   local binary = engine
-  local format_a = gsub(engine,"tex$",checkformat)
+  local format = gsub(engine,"tex$",checkformat)
   -- Special binary/format combos
   if specialformats[checkformat] and next(specialformats[checkformat]) then
     local t = specialformats[checkformat]
     local t_ngn = t[engine]
-    if t_ngn and next(t_ngn) then
+    if t_ngn then
       binary    = t_ngn.binary  or binary
+      format    = t_ngn.format  or format
       checkopts = t_ngn.options or checkopts
-      format_a    = t_ngn.format  or format_a
     end
   end
   -- Finalise format string
-  if format_a ~= "" then
-    format_a = " --fmt=" .. format_a
+  if format ~= "" then
+    format = " --fmt=" .. format
   end
   -- Special casing for XeTeX engine
   if match(engine, "xetex") and test_type.generated ~= pdfext then
@@ -780,7 +780,7 @@ function runtest(name, engine, hide, ext, test_type, breakout)
       -- Ensure lines are of a known length
       os_setenv .. " max_print_line=" .. maxprintline
         .. os_concat ..
-      binary .. format_a
+      binary .. format
         .. " " .. asciiopt .. " " .. checkopts
         .. setup(lvtfile)
         .. (hide and (" > " .. os_null) or "")

--- a/l3build-check.lua
+++ b/l3build-check.lua
@@ -764,7 +764,7 @@ function runtest(name, engine, hide, ext, pdfmode, breakout)
       -- Allow for local texmf files
       os_setenv .. " TEXMFCNF=." .. os_pathsep
         .. os_concat ..
-      (forcecheckepoch and set_epoch_cmd(epoch) or "") ..
+      set_epoch_cmd(epoch) ..
       -- Ensure lines are of a known length
       os_setenv .. " max_print_line=" .. maxprintline
         .. os_concat ..

--- a/l3build-check.lua
+++ b/l3build-check.lua
@@ -813,7 +813,7 @@ function runtest(name, engine, hide, ext, pdfmode, breakout)
            e7n ~= lveext and
            e7n ~= logext then
            local newname = gsub(file,"(%.[^.]+)$","." .. engine .. "%1")
-           if fileexists(testdir,newname) then
+           if fileexists(testdir .. "/" .. newname) then
              rm(testdir,newname)
            end
            ren(testdir,file,newname)

--- a/l3build-check.lua
+++ b/l3build-check.lua
@@ -1015,7 +1015,7 @@ function save(names)
       return 1
     end
     for _,engine in pairs(engines) do
-      local testengine = ((engine == stdengine and "") or "." .. engine)
+      local testengine = ((engine == stdengine and "") or ("." .. engine))
       local out_file = name .. testengine .. test_type.reference
       local gen_file = name .. "." .. engine .. test_type.generated
       print("Creating and copying " .. out_file)

--- a/l3build-check.lua
+++ b/l3build-check.lua
@@ -134,7 +134,7 @@ local function normalize_log(content,engine,errlevels)
        not match(line, "%.%.%.$") then
       return "", (lastline or "") .. line
     end
-    local line = (lastline or "") .. line
+    line = (lastline or "") .. line
     lastline = ""
     -- Zap ./ at begin of filename
     line = gsub(line, "%(%.%/", "(")
@@ -696,17 +696,17 @@ function runtest(name, engine, hide, ext, pdfmode, breakout)
   cp(lvtfile, fileexists(testfiledir .. "/" .. lvtfile)
     and testfiledir or unpackdir, testdir)
   local checkopts = checkopts
-  local engine = engine or stdengine
+  engine = engine or stdengine
   local binary = engine
-  local format = gsub(engine,"tex$",checkformat)
+  format = gsub(engine,"tex$",checkformat)
   -- Special binary/format combos
   if specialformats[checkformat] and next(specialformats[checkformat]) then
     local t = specialformats[checkformat]
-    if t[engine] and next(t[engine]) then
-      local t = t[engine]
-      binary    = t.binary  or binary
-      checkopts = t.options or checkopts
-      format    = t.format  or format
+    local t_ngn = t[engine]
+    if t_ngn and next(t_ngn) then
+      binary    = t_ngn.binary  or binary
+      checkopts = t_ngn.options or checkopts
+      format    = t_ngn.format  or format
     end
   end
   -- Finalise format string
@@ -807,11 +807,11 @@ function runtest(name, engine, hide, ext, pdfmode, breakout)
   for _,filetype in pairs(auxfiles) do
     for _,file in pairs(filelist(testdir, filetype)) do
       if match(file,"^" .. name .. ".[^.]+$") then
-        local ext = match(file, "%.[^.]+$")
-        if ext ~= lvtext and
-           ext ~= tlgext and
-           ext ~= lveext and
-           ext ~= logext then
+        local e7n = match(file, "%.[^.]+$")
+        if e7n ~= lvtext and
+           e7n ~= tlgext and
+           e7n ~= lveext and
+           e7n ~= logext then
            local newname = gsub(file,"(%.[^.]+)$","." .. engine .. "%1")
            if fileexists(testdir,newname) then
              rm(testdir,newname)
@@ -908,17 +908,12 @@ function check(names)
         end
       end
     end
-    -- https://stackoverflow.com/a/32167188
-    local function shuffle(tbl)
-      local len, random = #tbl, rnd
-      for i = len, 2, -1 do
-          local j = random(1, i)
-          tbl[i], tbl[j] = tbl[j], tbl[i]
-      end
-      return tbl
-    end
     if options["shuffle"] then
-      names = shuffle(names)
+      -- https://stackoverflow.com/a/32167188
+      for i = #names, 2, -1 do
+        local j = rnd(1, i)
+        names[i], names[j] = names[j], names[i]
+      end
     end
     -- Actually run the tests
     print("Running checks on")

--- a/l3build-ctan.lua
+++ b/l3build-ctan.lua
@@ -39,7 +39,7 @@ function copyctan()
     else
       for _,filetype in pairs(files) do
         for file,_ in pairs(tree(source,filetype)) do
-          local path = splitpath(file)
+          local path = dirname(file)
           local ctantarget = ctandir .. "/" .. ctanpkg .. "/"
             .. source .. "/" .. path
           mkdir(ctantarget)

--- a/l3build-file-functions.lua
+++ b/l3build-file-functions.lua
@@ -335,8 +335,8 @@ function tree(src_path, glob)
         fill(p_src, p_cwd, result)
       end
     else
-      for p_scr, p_cwd in pairs(result) do
-        fill(p_scr, p_cwd, new_result)
+      for p_src, p_cwd in pairs(result) do
+        fill(p_src, p_cwd, new_result)
       end
     end
     result = new_result

--- a/l3build-file-functions.lua
+++ b/l3build-file-functions.lua
@@ -312,13 +312,13 @@ function tree(src_path, glob)
     ---@param table table
     local function fill(p_src, p_cwd, table)
       for _, file in ipairs(filelist(p_cwd, glob_part)) do
-        p_src = p_src .. "/" .. file
+        local p_src_file = p_src .. "/" .. file
         if file ~= "." and file ~= ".." and
-          p_src ~= builddir -- TODO: ensure that `builddir` is properly formatted
+        p_src_file ~= builddir -- TODO: ensure that `builddir` is properly formatted
         then
-          p_cwd = p_cwd .. "/" .. file
-          if accept(p_cwd) then
-            table[p_src] = p_cwd
+          local p_cwd_file = p_cwd .. "/" .. file
+          if accept(p_cwd_file) then
+            table[p_src_file] = p_cwd_file
           end
         end
       end

--- a/l3build-help.lua
+++ b/l3build-help.lua
@@ -39,7 +39,7 @@ end
 function help()
   local function setup_list(list)
     local longest = 0
-    for k,v in pairs(list) do
+    for k,_ in pairs(list) do
       if k:len() > longest then
         longest = k:len()
       end
@@ -70,7 +70,7 @@ function help()
   end
   print("")
   print("Valid options are:")
-  local longest,t = setup_list(option_list)
+  longest,t = setup_list(option_list)
   for _,k in ipairs(t) do
     local opt = option_list[k]
     local filler = rep(" ", longest - k:len() + 1)

--- a/l3build-install.lua
+++ b/l3build-install.lua
@@ -97,7 +97,7 @@ function uninstall()
   if errorlevel ~= 0 then return errorlevel end
   -- Finally, clean up special locations
   for _,location in ipairs(tdslocations) do
-    local path,glob = splitpath(location)
+    local path = splitpath(location)
     errorlevel = zapdir(path)
     if errorlevel ~= 0 then return errorlevel end
   end
@@ -140,11 +140,11 @@ function install_files(target,full,dry_run)
           end
           local matched = false
           for _,location in ipairs(tdslocations) do
-            local path,glob = splitpath(location)
-            local pattern = glob_to_pattern(glob)
+            local l_dir,l_glob = splitpath(location)
+            local pattern = glob_to_pattern(l_glob)
             if match(filename,pattern) then
-              insert(paths,path)
-              insert(filenames,path .. sourcepath .. filename)
+              insert(paths,l_dir)
+              insert(filenames,l_dir .. sourcepath .. filename)
               matched = true
               break
             end
@@ -162,12 +162,12 @@ function install_files(target,full,dry_run)
     if next(filenames) then
       if not dry_run then
         for _,path in pairs(paths) do
-          local dir = target .. "/" .. path
-          if not cleanpaths[dir] then
-            errorlevel = cleandir(dir)
+          local dir_a = target .. "/" .. path
+          if not cleanpaths[dir_a] then
+            errorlevel = cleandir(dir_a)
             if errorlevel ~= 0 then return errorlevel end
           end
-          cleanpaths[dir] = true
+          cleanpaths[dir_a] = true
         end
       end
       for _,file in ipairs(filenames) do
@@ -192,17 +192,17 @@ function install_files(target,full,dry_run)
       exclude = exclude or { }
       dir = dir or currentdir
       local includelist = { }
-      local excludelist = { }
+      local excludelist_a = { }
       for _,glob_table in pairs(exclude) do
         for _,glob in pairs(glob_table) do
           for file,_ in pairs(tree(dir,glob)) do
-            excludelist[file] = true
+            excludelist_a[file] = true
           end
         end
       end
       for _,glob in pairs(include) do
         for file,_ in pairs(tree(dir,glob)) do
-          if not excludelist[file] then
+          if not excludelist_a[file] then
             insert(includelist, file)
           end
         end

--- a/l3build-install.lua
+++ b/l3build-install.lua
@@ -162,19 +162,19 @@ function install_files(target,full,dry_run)
     if next(filenames) then
       if not dry_run then
         for _,path in pairs(paths) do
-          local dir_a = target .. "/" .. path
-          if not cleanpaths[dir_a] then
-            errorlevel = cleandir(dir_a)
+          local target_path = target .. "/" .. path
+          if not cleanpaths[target_path] then
+            errorlevel = cleandir(target_path)
             if errorlevel ~= 0 then return errorlevel end
           end
-          cleanpaths[dir_a] = true
+          cleanpaths[target_path] = true
         end
       end
-      for _,file in ipairs(filenames) do
+      for _,name in ipairs(filenames) do
         if dry_run then
-          print("- " .. file)
+          print("- " .. name)
         else
-          local path,file = splitpath(file)
+          local path,file = splitpath(name)
           insert(installmap,
             {file = file, source = sourcepaths[file], dest = target .. "/" .. path})
         end
@@ -187,30 +187,30 @@ function install_files(target,full,dry_run)
   if errorlevel ~= 0 then return errorlevel end
 
     -- Creates a 'controlled' list of files
-    local function excludelist(dir,include,exclude)
+    local function create_list(dir,include,exclude)
+      dir = dir or currentdir
       include = include or { }
       exclude = exclude or { }
-      dir = dir or currentdir
-      local includelist = { }
-      local excludelist_a = { }
+      local excludelist = { }
       for _,glob_table in pairs(exclude) do
         for _,glob in pairs(glob_table) do
           for file,_ in pairs(tree(dir,glob)) do
-            excludelist_a[file] = true
+            excludelist[file] = true
           end
         end
       end
+      local ans = { }
       for _,glob in pairs(include) do
         for file,_ in pairs(tree(dir,glob)) do
-          if not excludelist_a[file] then
-            insert(includelist, file)
+          if not excludelist[file] then
+            insert(ans, file)
           end
         end
       end
-      return includelist
+      return ans
     end
 
-  local installlist = excludelist(unpackdir,installfiles,{scriptfiles})
+  local installlist = create_list(unpackdir,installfiles,{scriptfiles})
 
   if full then
     errorlevel = doc()
@@ -229,8 +229,8 @@ function install_files(target,full,dry_run)
     end
 
     -- Set up lists: global as they are also needed to do CTAN releases
-    typesetlist = excludelist(docfiledir,typesetfiles,{sourcefiles})
-    sourcelist = excludelist(sourcefiledir,sourcefiles,
+    typesetlist = create_list(docfiledir,typesetfiles,{sourcefiles})
+    sourcelist = create_list(sourcefiledir,sourcefiles,
       {bstfiles,installfiles,makeindexfiles,scriptfiles})
  
   if dry_run then

--- a/l3build-install.lua
+++ b/l3build-install.lua
@@ -97,7 +97,7 @@ function uninstall()
   if errorlevel ~= 0 then return errorlevel end
   -- Finally, clean up special locations
   for _,location in ipairs(tdslocations) do
-    local path = splitpath(location)
+    local path = dirname(location)
     errorlevel = zapdir(path)
     if errorlevel ~= 0 then return errorlevel end
   end

--- a/l3build-install.lua
+++ b/l3build-install.lua
@@ -187,7 +187,7 @@ function install_files(target,full,dry_run)
   if errorlevel ~= 0 then return errorlevel end
 
     -- Creates a 'controlled' list of files
-    local function create_list(dir,include,exclude)
+    local function create_file_list(dir,include,exclude)
       dir = dir or currentdir
       include = include or { }
       exclude = exclude or { }
@@ -199,18 +199,18 @@ function install_files(target,full,dry_run)
           end
         end
       end
-      local ans = { }
+      local result = { }
       for _,glob in pairs(include) do
         for file,_ in pairs(tree(dir,glob)) do
           if not excludelist[file] then
-            insert(ans, file)
+            insert(result, file)
           end
         end
       end
-      return ans
+      return result
     end
 
-  local installlist = create_list(unpackdir,installfiles,{scriptfiles})
+  local installlist = create_file_list(unpackdir,installfiles,{scriptfiles})
 
   if full then
     errorlevel = doc()
@@ -229,8 +229,8 @@ function install_files(target,full,dry_run)
     end
 
     -- Set up lists: global as they are also needed to do CTAN releases
-    typesetlist = create_list(docfiledir,typesetfiles,{sourcefiles})
-    sourcelist = create_list(sourcefiledir,sourcefiles,
+    typesetlist = create_file_list(docfiledir,typesetfiles,{sourcefiles})
+    sourcelist = create_file_list(sourcefiledir,sourcefiles,
       {bstfiles,installfiles,makeindexfiles,scriptfiles})
  
   if dry_run then

--- a/l3build-manifest-setup.lua
+++ b/l3build-manifest-setup.lua
@@ -221,18 +221,16 @@ end
 --]]
 
 manifest_sort_within_match = manifest_sort_within_match or function(files)
-  local f = files
-  table.sort(f)
-  return f
+  table.sort(files)
+  return files
 end
 
 manifest_sort_within_group = manifest_sort_within_group or function(files)
-  local f = files
   --[[
       -- no-op by default; make your own definition to customise. E.g.:
-      table.sort(f)
+      table.sort(files)
   --]]
-  return f
+  return files
 end
 
 --[[

--- a/l3build-stdmain.lua
+++ b/l3build-stdmain.lua
@@ -22,6 +22,8 @@ for those people who are interested.
 
 --]]
 
+local lfs = require("lfs")
+
 local exit   = os.exit
 local insert = table.insert
 

--- a/l3build-tagging.lua
+++ b/l3build-tagging.lua
@@ -51,7 +51,7 @@ local function update_file_tag(file,tagname,tagdate)
   else
     local path = dirname(file)
     ren(path,filename,filename .. ".bak")
-    local f = assert(open(file,"w"))
+    f = assert(open(file,"w"))
     -- Convert line ends back if required during write
     -- Watch for the second return value!
     f:write((gsub(updated_content,"\n",os_newline)))

--- a/l3build-typesetting.lua
+++ b/l3build-typesetting.lua
@@ -38,11 +38,11 @@ local os_type = os.type
 function dvitopdf(name, dir, engine, hide)
   run(
     dir,
-    (forcecheckepoch and set_epoch_cmd(epoch) or "") ..
+    set_epoch_cmd(epoch) ..
     "dvips " .. name .. dviext
       .. (hide and (" > " .. os_null) or "")
       .. os_concat ..
-   "ps2pdf " .. ps2pdfopt .. name .. psext
+    "ps2pdf " .. ps2pdfopt .. name .. psext
       .. (hide and (" > " .. os_null) or "")
   )
 end
@@ -68,7 +68,7 @@ function runcmd(cmd,dir,vars)
   for _,var in pairs(vars) do
     env = env .. os_concat .. os_setenv .. " " .. var .. "=" .. envpaths
   end
-  return run(dir,(forcedocepoch and set_epoch_cmd(epoch) or "") .. env .. os_concat .. cmd)
+  return run(dir,set_epoch_cmd(epoch) .. env .. os_concat .. cmd)
 end
 
 function biber(name,dir)

--- a/l3build-typesetting.lua
+++ b/l3build-typesetting.lua
@@ -49,9 +49,9 @@ end
 
 -- An auxiliary used to set up the environmental variables
 function runcmd(cmd,dir,vars)
-  local dir = dir or "."
-  local dir = abspath(dir)
-  local vars = vars or {}
+  dir = dir or "."
+  dir = abspath(dir)
+  vars = vars or {}
   -- Allow for local texmf files
   local env = os_setenv .. " TEXMFCNF=." .. os_pathsep
   local localtexmf = ""
@@ -80,7 +80,7 @@ function biber(name,dir)
 end
 
 function bibtex(name,dir)
-  local dir = dir or "."
+  dir = dir or "."
   if fileexists(dir .. "/" .. name .. ".aux") then
     -- LaTeX always generates an .aux file, so there is a need to
     -- look inside it for a \citation line
@@ -105,7 +105,7 @@ function bibtex(name,dir)
 end
 
 function makeindex(name,dir,inext,outext,logext,style)
-  local dir = dir or "."
+  dir = dir or "."
   if fileexists(dir .. "/" .. name .. inext) then
     if style == "" then style = nil end
     return runcmd(makeindexexe .. " " .. makeindexopts
@@ -119,15 +119,15 @@ function makeindex(name,dir,inext,outext,logext,style)
 end
 
 function tex(file,dir,cmd)
-  local dir = dir or "."
-  local cmd = cmd or typesetexe .. typesetopts
+  dir = dir or "."
+  cmd = cmd or typesetexe .. typesetopts
   return runcmd(cmd .. " \"" .. typesetcmds
     .. "\\input " .. file .. "\"",
     dir,{"TEXINPUTS","LUAINPUTS"})
 end
 
 local function typesetpdf(file,dir)
-  local dir = dir or "."
+  dir = dir or "."
   local name = jobname(file)
   print("Typesetting " .. name)
   local fn = typeset
@@ -141,7 +141,7 @@ local function typesetpdf(file,dir)
     print(" ! Compilation failed")
     return errorlevel
   end
-  pdfname = name .. pdfext
+  local pdfname = name .. pdfext
   rm(docfiledir,pdfname)
   return cp(pdfname,dir,docfiledir)
 end
@@ -226,7 +226,7 @@ function doc(files)
             end
             -- Now know if we should typeset this source
             if typeset then
-              local errorlevel = typesetpdf(srcname,path)
+              errorlevel = typesetpdf(srcname,path)
               if errorlevel ~= 0 then
                 return errorlevel
               else

--- a/l3build-unpack.lua
+++ b/l3build-unpack.lua
@@ -22,8 +22,6 @@ for those people who are interested.
 
 --]]
 
-local execute          = os.execute
-
 -- Unpack the package files using an 'isolated' system: this requires
 -- a copy of the 'basic' DocStrip program, which is used then removed
 function unpack(sources, sourcedirs)

--- a/l3build-upload.lua
+++ b/l3build-upload.lua
@@ -254,14 +254,6 @@ function construct_ctan_post(uploadfile,debug)
   ctan_field("uploader",     uploadconfig.uploader,      255, "Name of uploader",                    true,  false )
   ctan_field("version",      uploadconfig.version,        32, "Package version",                     true,  false )
 
-  --[=[ `qq` is unused because line 258 is commented
-  -- finish constructing the curl command:
-  local qq = '"'
-  if os_type == "windows" then
-    qq = '\"'
-  end
-  --]=]
--- commandline   ctan_post = ctan_post .. ' --form ' .. qq .. 'file=@' .. tostring(uploadfile) .. ';filename=' .. tostring(uploadfile) .. qq
   ctan_post = ctan_post .. '\nform="file=@' .. tostring(uploadfile) .. ';filename=' .. tostring(uploadfile) .. '"'
 
   return ctan_post

--- a/l3build-upload.lua
+++ b/l3build-upload.lua
@@ -78,6 +78,12 @@ end
 -- if upload is anything else, the user will be prompted whether to upload.
 -- For now, this is undocumented. I think I would prefer to keep it always set to ask for the time being.
 
+local ctan_post -- this is private to the module
+
+-- TODO: next is a public global method,
+-- but following functions are semantically local
+-- despite they are declared globally.
+
 function upload(tagnames)
 
   local uploadfile = ctanzip..".zip"
@@ -100,7 +106,7 @@ function upload(tagnames)
 
   uploadconfig.note =   uploadconfig.note  or file_contents(uploadconfig.note_file)
 
-  local tagnames = tagnames or { }
+  tagnames = tagnames or { }
   uploadconfig.version = tagnames[1] or uploadconfig.version
 
   local override_update_check = false
@@ -214,7 +220,7 @@ end
 
 function shell(s)
   local h = assert(popen(s, 'r'))
-  t = assert(h:read('*a'))
+  local t = assert(h:read('*a'))
   h:close()
   return t
 end
@@ -248,11 +254,13 @@ function construct_ctan_post(uploadfile,debug)
   ctan_field("uploader",     uploadconfig.uploader,      255, "Name of uploader",                    true,  false )
   ctan_field("version",      uploadconfig.version,        32, "Package version",                     true,  false )
 
+  --[=[ `qq` is unused because line 258 is commented
   -- finish constructing the curl command:
   local qq = '"'
   if os_type == "windows" then
     qq = '\"'
   end
+  --]=]
 -- commandline   ctan_post = ctan_post .. ' --form ' .. qq .. 'file=@' .. tostring(uploadfile) .. ';filename=' .. tostring(uploadfile) .. qq
   ctan_post = ctan_post .. '\nform="file=@' .. tostring(uploadfile) .. ';filename=' .. tostring(uploadfile) .. '"'
 
@@ -352,7 +360,7 @@ function file_contents (filename)
     local f= open(filename,"r")
     if f==nil then
       return nil
-    else 
+    else
       local s = f:read("*all")
       close(f)
       return s


### PR DESCRIPTION
Simpler code,
useless locals removed,
missing locals added,
bad file exists call

Some locals have been renamed when they hide outer locals.
This is good practice useful in particular when the whole code does not fit in just one screen.

Some code comments to explain the changes.
You may have to check some `show comment` box in the Files changed pane.