### PR TITLE
Refactor require

### DIFF
--- a/l3build-arguments.lua
+++ b/l3build-arguments.lua
@@ -201,6 +201,7 @@ local function argparse()
   -- to grab arg for optionals where appropriate
   local i = 2
   while i <= #arg do
+    ::top::
     local a = arg[i]
     -- Terminate search for options
     if a == "--" then
@@ -252,8 +253,22 @@ local function argparse()
          end
         end
       else
-        stderr:write("Unknown option " .. a .."\n")
-        return { target = "help" }
+        -- Private special debugging options "--debug-<key>"
+        local key = match(a, "^%-%-debug%-(%w[%w%d_]*)")
+        if key then
+          ---@type l3build_t
+          local l3build = require("l3build")
+          l3build.debug[key] = true
+          i = i + 1
+          if i <= #arg then
+            goto top
+          else
+            break
+          end
+        else
+          stderr:write("Unknown option " .. a .."\n")
+          return { target = "help" }
+        end
       end
       -- Store the result
       if optarg then

--- a/l3build-aux.lua
+++ b/l3build-aux.lua
@@ -60,19 +60,22 @@ function normalise_epoch(epoch)
   end
 end
 
----CLI command to set the epoch, will be run while checking or typesetting
+---Returns the CLI command (ending with `os_concat`) to set the epoch
+---when forcecheckepoch is true, a void string otherwise.
+---Will be run while checking or typesetting
 ---@param epoch string
 ---@return string
 ---@see check, typesetting
 ---@usage private?
 function set_epoch_cmd(epoch)
-  return
+  return forcecheckepoch and (
     os_setenv .. " SOURCE_DATE_EPOCH=" .. epoch
       .. os_concat ..
     os_setenv .. " SOURCE_DATE_EPOCH_TEX_PRIMITIVES=1"
       .. os_concat ..
     os_setenv .. " FORCE_SOURCE_DATE=1"
       .. os_concat
+  ) or ""
 end
 
 ---Returns the script name depending on the calling sequence.

--- a/l3build-aux.lua
+++ b/l3build-aux.lua
@@ -64,11 +64,12 @@ end
 ---when forcecheckepoch is true, a void string otherwise.
 ---Will be run while checking or typesetting
 ---@param epoch string
+---@param force boolean
 ---@return string
 ---@see check, typesetting
 ---@usage private?
-function set_epoch_cmd(epoch)
-  return forcecheckepoch and (
+function set_epoch_cmd(epoch, force)
+  return force and (
     os_setenv .. " SOURCE_DATE_EPOCH=" .. epoch
       .. os_concat ..
     os_setenv .. " SOURCE_DATE_EPOCH_TEX_PRIMITIVES=1"

--- a/l3build-check.lua
+++ b/l3build-check.lua
@@ -435,7 +435,7 @@ local function normalize_lua_log(content,luatex)
       end
     end
     -- Look for another form of \discretionary, replacing a "-"
-    pattern = "^%.+\\discretionary replacing *$"
+    local pattern = "^%.+\\discretionary replacing *$"
     if match(line, pattern) then
       return "", line
     else

--- a/l3build-check.lua
+++ b/l3build-check.lua
@@ -776,7 +776,7 @@ function runtest(name, engine, hide, ext, test_type, breakout)
       -- Allow for local texmf files
       os_setenv .. " TEXMFCNF=." .. os_pathsep
         .. os_concat ..
-      set_epoch_cmd(epoch) ..
+      set_epoch_cmd(epoch, forcecheckepoch) ..
       -- Ensure lines are of a known length
       os_setenv .. " max_print_line=" .. maxprintline
         .. os_concat ..

--- a/l3build-check.lua
+++ b/l3build-check.lua
@@ -806,18 +806,12 @@ function runtest(name, engine, hide, ext, pdfmode, breakout)
   -- Store secondary files for this engine
   for _,filetype in pairs(auxfiles) do
     for _,file in pairs(filelist(testdir, filetype)) do
-      if match(file,"^" .. name .. ".[^.]+$") then
-        local e7n = match(file, "%.[^.]+$")
-        if e7n ~= lvtext and
-           e7n ~= tlgext and
-           e7n ~= lveext and
-           e7n ~= logext then
-           local newname = gsub(file,"(%.[^.]+)$","." .. engine .. "%1")
-           if fileexists(testdir .. "/" .. newname) then
-             rm(testdir,newname)
-           end
-           ren(testdir,file,newname)
+      if match(file,"^" .. name .. "%.[^.]+$") then
+        local newname = gsub(file,"(%.[^.]+)$","." .. engine .. "%1")
+        if fileexists(testdir .. "/" .. newname) then
+          rmfile(testdir,newname)
         end
+        ren(testdir,file,newname)
       end
     end
   end

--- a/l3build-check.lua
+++ b/l3build-check.lua
@@ -698,7 +698,7 @@ function runtest(name, engine, hide, ext, pdfmode, breakout)
   local checkopts = checkopts
   engine = engine or stdengine
   local binary = engine
-  format = gsub(engine,"tex$",checkformat)
+  local format_a = gsub(engine,"tex$",checkformat)
   -- Special binary/format combos
   if specialformats[checkformat] and next(specialformats[checkformat]) then
     local t = specialformats[checkformat]
@@ -706,12 +706,12 @@ function runtest(name, engine, hide, ext, pdfmode, breakout)
     if t_ngn and next(t_ngn) then
       binary    = t_ngn.binary  or binary
       checkopts = t_ngn.options or checkopts
-      format    = t_ngn.format  or format
+      format_a    = t_ngn.format  or format_a
     end
   end
   -- Finalise format string
-  if format ~= "" then
-    format = " --fmt=" .. format
+  if format_a ~= "" then
+    format_a = " --fmt=" .. format_a
   end
   -- Special casing for XeTeX engine
   if match(engine, "xetex") and not pdfmode then
@@ -768,7 +768,7 @@ function runtest(name, engine, hide, ext, pdfmode, breakout)
       -- Ensure lines are of a known length
       os_setenv .. " max_print_line=" .. maxprintline
         .. os_concat ..
-      binary .. format
+      binary .. format_a
         .. " " .. asciiopt .. " " .. checkopts
         .. setup(lvtfile)
         .. (hide and (" > " .. os_null) or "")

--- a/l3build-check.lua
+++ b/l3build-check.lua
@@ -34,7 +34,7 @@ local luatex_version   = status.luatex_version
 
 local len              = string.len
 local char             = string.char
-local frmt             = string.format
+local str_format       = string.format
 local gmatch           = string.gmatch
 local gsub             = string.gsub
 local match            = string.match
@@ -269,7 +269,7 @@ local function normalize_log(content,engine,errlevels)
     -- tidy up to match pdfTeX if an ASCII engine is in use
     if next(asciiengines) then
       for i = 128, 255 do
-        line = gsub(line, utf8_char(i), "^^" .. frmt("%02x", i))
+        line = gsub(line, utf8_char(i), "^^" .. str_format("%02x", i))
       end
     end
     return line, lastline
@@ -345,7 +345,7 @@ local function normalize_lua_log(content,luatex)
         l,
         m .. " (%-?)%d+%.%d+",
         m .. " %1"
-          .. frmt(
+          .. str_format(
             "%.3f",
             match(line, m .. " %-?(%d+%.%d+)") or 0
           )
@@ -714,13 +714,13 @@ function runtest(name, engine, hide, ext, test_type, breakout)
   local binary = engine
   local format = gsub(engine,"tex$",checkformat)
   -- Special binary/format combos
-  if specialformats[checkformat] and next(specialformats[checkformat]) then
-    local t = specialformats[checkformat]
-    local t_ngn = t[engine]
-    if t_ngn then
-      binary    = t_ngn.binary  or binary
-      format    = t_ngn.format  or format
-      checkopts = t_ngn.options or checkopts
+  local special_check = specialformats[checkformat]
+  if special_check and next(special_check) then
+    local engine_info = special_check[engine]
+    if engine_info then
+      binary    = engine_info.binary  or binary
+      format    = engine_info.format  or format
+      checkopts = engine_info.options or checkopts
     end
   end
   -- Finalise format string
@@ -933,10 +933,8 @@ function check(names)
     end
     -- Actually run the tests
     print("Running checks on")
-    local i = 0
-    for _,name in ipairs(names) do
-      i = i + 1
-      print("  " .. name .. " (" ..  i.. "/" .. #names ..")")
+    for i, name in ipairs(names) do
+      print("  " .. name .. " (" ..  i .. "/" .. #names ..")")
       local errlevel = runcheck(name, hide)
       -- Return value must be 1 not errlevel
       if errlevel ~= 0 then
@@ -1015,7 +1013,7 @@ function save(names)
       return 1
     end
     for _,engine in pairs(engines) do
-      local testengine = ((engine == stdengine and "") or ("." .. engine))
+      local testengine = engine == stdengine and "" or ("." .. engine)
       local out_file = name .. testengine .. test_type.reference
       local gen_file = name .. "." .. engine .. test_type.generated
       print("Creating and copying " .. out_file)

--- a/l3build-check.lua
+++ b/l3build-check.lua
@@ -34,7 +34,7 @@ local luatex_version   = status.luatex_version
 
 local len              = string.len
 local char             = string.char
-local format           = string.format
+local frmt             = string.format
 local gmatch           = string.gmatch
 local gsub             = string.gsub
 local match            = string.match
@@ -269,7 +269,7 @@ local function normalize_log(content,engine,errlevels)
     -- tidy up to match pdfTeX if an ASCII engine is in use
     if next(asciiengines) then
       for i = 128, 255 do
-        line = gsub(line, utf8_char(i), "^^" .. format("%02x", i))
+        line = gsub(line, utf8_char(i), "^^" .. frmt("%02x", i))
       end
     end
     return line, lastline
@@ -345,7 +345,7 @@ local function normalize_lua_log(content,luatex)
         l,
         m .. " (%-?)%d+%.%d+",
         m .. " %1"
-          .. format(
+          .. frmt(
             "%.3f",
             match(line, m .. " %-?(%d+%.%d+)") or 0
           )
@@ -712,20 +712,20 @@ function runtest(name, engine, hide, ext, test_type, breakout)
   local checkopts = checkopts
   engine = engine or stdengine
   local binary = engine
-  local format_a = gsub(engine,"tex$",checkformat)
+  local format = gsub(engine,"tex$",checkformat)
   -- Special binary/format combos
   if specialformats[checkformat] and next(specialformats[checkformat]) then
     local t = specialformats[checkformat]
     local t_ngn = t[engine]
-    if t_ngn and next(t_ngn) then
+    if t_ngn then
       binary    = t_ngn.binary  or binary
+      format    = t_ngn.format  or format
       checkopts = t_ngn.options or checkopts
-      format_a    = t_ngn.format  or format_a
     end
   end
   -- Finalise format string
-  if format_a ~= "" then
-    format_a = " --fmt=" .. format_a
+  if format ~= "" then
+    format = " --fmt=" .. format
   end
   -- Special casing for XeTeX engine
   if match(engine, "xetex") and test_type.generated ~= pdfext then
@@ -780,7 +780,7 @@ function runtest(name, engine, hide, ext, test_type, breakout)
       -- Ensure lines are of a known length
       os_setenv .. " max_print_line=" .. maxprintline
         .. os_concat ..
-      binary .. format_a
+      binary .. format
         .. " " .. asciiopt .. " " .. checkopts
         .. setup(lvtfile)
         .. (hide and (" > " .. os_null) or "")

--- a/l3build-check.lua
+++ b/l3build-check.lua
@@ -764,7 +764,7 @@ function runtest(name, engine, hide, ext, pdfmode, breakout)
       -- Allow for local texmf files
       os_setenv .. " TEXMFCNF=." .. os_pathsep
         .. os_concat ..
-      (forcecheckepoch and set_epoch_cmd(epoch) or "") ..
+      set_epoch_cmd(epoch) ..
       -- Ensure lines are of a known length
       os_setenv .. " max_print_line=" .. maxprintline
         .. os_concat ..

--- a/l3build-check.lua
+++ b/l3build-check.lua
@@ -813,7 +813,7 @@ function runtest(name, engine, hide, ext, pdfmode, breakout)
            e7n ~= lveext and
            e7n ~= logext then
            local newname = gsub(file,"(%.[^.]+)$","." .. engine .. "%1")
-           if fileexists(testdir,newname) then
+           if fileexists(testdir .. "/" .. newname) then
              rm(testdir,newname)
            end
            ren(testdir,file,newname)

--- a/l3build-check.lua
+++ b/l3build-check.lua
@@ -1015,7 +1015,7 @@ function save(names)
       return 1
     end
     for _,engine in pairs(engines) do
-      local testengine = ((engine == stdengine and "") or "." .. engine)
+      local testengine = ((engine == stdengine and "") or ("." .. engine))
       local out_file = name .. testengine .. test_type.reference
       local gen_file = name .. "." .. engine .. test_type.generated
       print("Creating and copying " .. out_file)

--- a/l3build-check.lua
+++ b/l3build-check.lua
@@ -134,7 +134,7 @@ local function normalize_log(content,engine,errlevels)
        not match(line, "%.%.%.$") then
       return "", (lastline or "") .. line
     end
-    local line = (lastline or "") .. line
+    line = (lastline or "") .. line
     lastline = ""
     -- Zap ./ at begin of filename
     line = gsub(line, "%(%.%/", "(")
@@ -696,17 +696,17 @@ function runtest(name, engine, hide, ext, pdfmode, breakout)
   cp(lvtfile, fileexists(testfiledir .. "/" .. lvtfile)
     and testfiledir or unpackdir, testdir)
   local checkopts = checkopts
-  local engine = engine or stdengine
+  engine = engine or stdengine
   local binary = engine
-  local format = gsub(engine,"tex$",checkformat)
+  format = gsub(engine,"tex$",checkformat)
   -- Special binary/format combos
   if specialformats[checkformat] and next(specialformats[checkformat]) then
     local t = specialformats[checkformat]
-    if t[engine] and next(t[engine]) then
-      local t = t[engine]
-      binary    = t.binary  or binary
-      checkopts = t.options or checkopts
-      format    = t.format  or format
+    local t_ngn = t[engine]
+    if t_ngn and next(t_ngn) then
+      binary    = t_ngn.binary  or binary
+      checkopts = t_ngn.options or checkopts
+      format    = t_ngn.format  or format
     end
   end
   -- Finalise format string
@@ -807,11 +807,11 @@ function runtest(name, engine, hide, ext, pdfmode, breakout)
   for _,filetype in pairs(auxfiles) do
     for _,file in pairs(filelist(testdir, filetype)) do
       if match(file,"^" .. name .. ".[^.]+$") then
-        local ext = match(file, "%.[^.]+$")
-        if ext ~= lvtext and
-           ext ~= tlgext and
-           ext ~= lveext and
-           ext ~= logext then
+        local e7n = match(file, "%.[^.]+$")
+        if e7n ~= lvtext and
+           e7n ~= tlgext and
+           e7n ~= lveext and
+           e7n ~= logext then
            local newname = gsub(file,"(%.[^.]+)$","." .. engine .. "%1")
            if fileexists(testdir,newname) then
              rm(testdir,newname)
@@ -908,17 +908,12 @@ function check(names)
         end
       end
     end
-    -- https://stackoverflow.com/a/32167188
-    local function shuffle(tbl)
-      local len, random = #tbl, rnd
-      for i = len, 2, -1 do
-          local j = random(1, i)
-          tbl[i], tbl[j] = tbl[j], tbl[i]
-      end
-      return tbl
-    end
     if options["shuffle"] then
-      names = shuffle(names)
+      -- https://stackoverflow.com/a/32167188
+      for i = #names, 2, -1 do
+        local j = rnd(1, i)
+        names[i], names[j] = names[j], names[i]
+      end
     end
     -- Actually run the tests
     print("Running checks on")

--- a/l3build-ctan.lua
+++ b/l3build-ctan.lua
@@ -39,7 +39,7 @@ function copyctan()
     else
       for _,filetype in pairs(files) do
         for file,_ in pairs(tree(source,filetype)) do
-          local path = splitpath(file)
+          local path = dirname(file)
           local ctantarget = ctandir .. "/" .. ctanpkg .. "/"
             .. source .. "/" .. path
           mkdir(ctantarget)

--- a/l3build-file-functions.lua
+++ b/l3build-file-functions.lua
@@ -335,8 +335,8 @@ function tree(src_path, glob)
         fill(p_src, p_cwd, result)
       end
     else
-      for p_scr, p_cwd in pairs(result) do
-        fill(p_scr, p_cwd, new_result)
+      for p_src, p_cwd in pairs(result) do
+        fill(p_src, p_cwd, new_result)
       end
     end
     result = new_result

--- a/l3build-file-functions.lua
+++ b/l3build-file-functions.lua
@@ -312,13 +312,13 @@ function tree(src_path, glob)
     ---@param table table
     local function fill(p_src, p_cwd, table)
       for _, file in ipairs(filelist(p_cwd, glob_part)) do
-        p_src = p_src .. "/" .. file
+        local p_src_file = p_src .. "/" .. file
         if file ~= "." and file ~= ".." and
-          p_src ~= builddir -- TODO: ensure that `builddir` is properly formatted
+        p_src_file ~= builddir -- TODO: ensure that `builddir` is properly formatted
         then
-          p_cwd = p_cwd .. "/" .. file
-          if accept(p_cwd) then
-            table[p_src] = p_cwd
+          local p_cwd_file = p_cwd .. "/" .. file
+          if accept(p_cwd_file) then
+            table[p_src_file] = p_cwd_file
           end
         end
       end

--- a/l3build-help.lua
+++ b/l3build-help.lua
@@ -39,7 +39,7 @@ end
 function help()
   local function setup_list(list)
     local longest = 0
-    for k,v in pairs(list) do
+    for k,_ in pairs(list) do
       if k:len() > longest then
         longest = k:len()
       end
@@ -70,7 +70,7 @@ function help()
   end
   print("")
   print("Valid options are:")
-  local longest,t = setup_list(option_list)
+  longest,t = setup_list(option_list)
   for _,k in ipairs(t) do
     local opt = option_list[k]
     local filler = rep(" ", longest - k:len() + 1)

--- a/l3build-install.lua
+++ b/l3build-install.lua
@@ -97,7 +97,7 @@ function uninstall()
   if errorlevel ~= 0 then return errorlevel end
   -- Finally, clean up special locations
   for _,location in ipairs(tdslocations) do
-    local path,glob = splitpath(location)
+    local path = splitpath(location)
     errorlevel = zapdir(path)
     if errorlevel ~= 0 then return errorlevel end
   end
@@ -140,11 +140,11 @@ function install_files(target,full,dry_run)
           end
           local matched = false
           for _,location in ipairs(tdslocations) do
-            local path,glob = splitpath(location)
-            local pattern = glob_to_pattern(glob)
+            local l_dir,l_glob = splitpath(location)
+            local pattern = glob_to_pattern(l_glob)
             if match(filename,pattern) then
-              insert(paths,path)
-              insert(filenames,path .. sourcepath .. filename)
+              insert(paths,l_dir)
+              insert(filenames,l_dir .. sourcepath .. filename)
               matched = true
               break
             end
@@ -162,12 +162,12 @@ function install_files(target,full,dry_run)
     if next(filenames) then
       if not dry_run then
         for _,path in pairs(paths) do
-          local dir = target .. "/" .. path
-          if not cleanpaths[dir] then
-            errorlevel = cleandir(dir)
+          local dir_a = target .. "/" .. path
+          if not cleanpaths[dir_a] then
+            errorlevel = cleandir(dir_a)
             if errorlevel ~= 0 then return errorlevel end
           end
-          cleanpaths[dir] = true
+          cleanpaths[dir_a] = true
         end
       end
       for _,file in ipairs(filenames) do
@@ -192,17 +192,17 @@ function install_files(target,full,dry_run)
       exclude = exclude or { }
       dir = dir or currentdir
       local includelist = { }
-      local excludelist = { }
+      local excludelist_a = { }
       for _,glob_table in pairs(exclude) do
         for _,glob in pairs(glob_table) do
           for file,_ in pairs(tree(dir,glob)) do
-            excludelist[file] = true
+            excludelist_a[file] = true
           end
         end
       end
       for _,glob in pairs(include) do
         for file,_ in pairs(tree(dir,glob)) do
-          if not excludelist[file] then
+          if not excludelist_a[file] then
             insert(includelist, file)
           end
         end

--- a/l3build-install.lua
+++ b/l3build-install.lua
@@ -162,19 +162,19 @@ function install_files(target,full,dry_run)
     if next(filenames) then
       if not dry_run then
         for _,path in pairs(paths) do
-          local dir_a = target .. "/" .. path
-          if not cleanpaths[dir_a] then
-            errorlevel = cleandir(dir_a)
+          local target_path = target .. "/" .. path
+          if not cleanpaths[target_path] then
+            errorlevel = cleandir(target_path)
             if errorlevel ~= 0 then return errorlevel end
           end
-          cleanpaths[dir_a] = true
+          cleanpaths[target_path] = true
         end
       end
-      for _,file in ipairs(filenames) do
+      for _,name in ipairs(filenames) do
         if dry_run then
-          print("- " .. file)
+          print("- " .. name)
         else
-          local path,file = splitpath(file)
+          local path,file = splitpath(name)
           insert(installmap,
             {file = file, source = sourcepaths[file], dest = target .. "/" .. path})
         end
@@ -187,30 +187,30 @@ function install_files(target,full,dry_run)
   if errorlevel ~= 0 then return errorlevel end
 
     -- Creates a 'controlled' list of files
-    local function excludelist(dir,include,exclude)
+    local function create_list(dir,include,exclude)
+      dir = dir or currentdir
       include = include or { }
       exclude = exclude or { }
-      dir = dir or currentdir
-      local includelist = { }
-      local excludelist_a = { }
+      local excludelist = { }
       for _,glob_table in pairs(exclude) do
         for _,glob in pairs(glob_table) do
           for file,_ in pairs(tree(dir,glob)) do
-            excludelist_a[file] = true
+            excludelist[file] = true
           end
         end
       end
+      local ans = { }
       for _,glob in pairs(include) do
         for file,_ in pairs(tree(dir,glob)) do
-          if not excludelist_a[file] then
-            insert(includelist, file)
+          if not excludelist[file] then
+            insert(ans, file)
           end
         end
       end
-      return includelist
+      return ans
     end
 
-  local installlist = excludelist(unpackdir,installfiles,{scriptfiles})
+  local installlist = create_list(unpackdir,installfiles,{scriptfiles})
 
   if full then
     errorlevel = doc()
@@ -229,8 +229,8 @@ function install_files(target,full,dry_run)
     end
 
     -- Set up lists: global as they are also needed to do CTAN releases
-    typesetlist = excludelist(docfiledir,typesetfiles,{sourcefiles})
-    sourcelist = excludelist(sourcefiledir,sourcefiles,
+    typesetlist = create_list(docfiledir,typesetfiles,{sourcefiles})
+    sourcelist = create_list(sourcefiledir,sourcefiles,
       {bstfiles,installfiles,makeindexfiles,scriptfiles})
  
   if dry_run then

--- a/l3build-install.lua
+++ b/l3build-install.lua
@@ -97,7 +97,7 @@ function uninstall()
   if errorlevel ~= 0 then return errorlevel end
   -- Finally, clean up special locations
   for _,location in ipairs(tdslocations) do
-    local path = splitpath(location)
+    local path = dirname(location)
     errorlevel = zapdir(path)
     if errorlevel ~= 0 then return errorlevel end
   end

--- a/l3build-install.lua
+++ b/l3build-install.lua
@@ -187,7 +187,7 @@ function install_files(target,full,dry_run)
   if errorlevel ~= 0 then return errorlevel end
 
     -- Creates a 'controlled' list of files
-    local function create_list(dir,include,exclude)
+    local function create_file_list(dir,include,exclude)
       dir = dir or currentdir
       include = include or { }
       exclude = exclude or { }
@@ -199,18 +199,18 @@ function install_files(target,full,dry_run)
           end
         end
       end
-      local ans = { }
+      local result = { }
       for _,glob in pairs(include) do
         for file,_ in pairs(tree(dir,glob)) do
           if not excludelist[file] then
-            insert(ans, file)
+            insert(result, file)
           end
         end
       end
-      return ans
+      return result
     end
 
-  local installlist = create_list(unpackdir,installfiles,{scriptfiles})
+  local installlist = create_file_list(unpackdir,installfiles,{scriptfiles})
 
   if full then
     errorlevel = doc()
@@ -229,8 +229,8 @@ function install_files(target,full,dry_run)
     end
 
     -- Set up lists: global as they are also needed to do CTAN releases
-    typesetlist = create_list(docfiledir,typesetfiles,{sourcefiles})
-    sourcelist = create_list(sourcefiledir,sourcefiles,
+    typesetlist = create_file_list(docfiledir,typesetfiles,{sourcefiles})
+    sourcelist = create_file_list(sourcefiledir,sourcefiles,
       {bstfiles,installfiles,makeindexfiles,scriptfiles})
  
   if dry_run then

--- a/l3build-manifest-setup.lua
+++ b/l3build-manifest-setup.lua
@@ -221,18 +221,16 @@ end
 --]]
 
 manifest_sort_within_match = manifest_sort_within_match or function(files)
-  local f = files
-  table.sort(f)
-  return f
+  table.sort(files)
+  return files
 end
 
 manifest_sort_within_group = manifest_sort_within_group or function(files)
-  local f = files
   --[[
       -- no-op by default; make your own definition to customise. E.g.:
-      table.sort(f)
+      table.sort(files)
   --]]
-  return f
+  return files
 end
 
 --[[

--- a/l3build-stdmain.lua
+++ b/l3build-stdmain.lua
@@ -22,6 +22,8 @@ for those people who are interested.
 
 --]]
 
+local lfs = require("lfs")
+
 local exit   = os.exit
 local insert = table.insert
 

--- a/l3build-tagging.lua
+++ b/l3build-tagging.lua
@@ -51,7 +51,7 @@ local function update_file_tag(file,tagname,tagdate)
   else
     local path = dirname(file)
     ren(path,filename,filename .. ".bak")
-    local f = assert(open(file,"w"))
+    f = assert(open(file,"w"))
     -- Convert line ends back if required during write
     -- Watch for the second return value!
     f:write((gsub(updated_content,"\n",os_newline)))

--- a/l3build-typesetting.lua
+++ b/l3build-typesetting.lua
@@ -38,11 +38,11 @@ local os_type = os.type
 function dvitopdf(name, dir, engine, hide)
   run(
     dir,
-    (forcecheckepoch and set_epoch_cmd(epoch) or "") ..
+    set_epoch_cmd(epoch) ..
     "dvips " .. name .. dviext
       .. (hide and (" > " .. os_null) or "")
       .. os_concat ..
-   "ps2pdf " .. ps2pdfopt .. name .. psext
+    "ps2pdf " .. ps2pdfopt .. name .. psext
       .. (hide and (" > " .. os_null) or "")
   )
 end
@@ -68,7 +68,7 @@ function runcmd(cmd,dir,vars)
   for _,var in pairs(vars) do
     env = env .. os_concat .. os_setenv .. " " .. var .. "=" .. envpaths
   end
-  return run(dir,(forcedocepoch and set_epoch_cmd(epoch) or "") .. env .. os_concat .. cmd)
+  return run(dir,set_epoch_cmd(epoch) .. env .. os_concat .. cmd)
 end
 
 function biber(name,dir)

--- a/l3build-typesetting.lua
+++ b/l3build-typesetting.lua
@@ -49,9 +49,9 @@ end
 
 -- An auxiliary used to set up the environmental variables
 function runcmd(cmd,dir,vars)
-  local dir = dir or "."
-  local dir = abspath(dir)
-  local vars = vars or {}
+  dir = dir or "."
+  dir = abspath(dir)
+  vars = vars or {}
   -- Allow for local texmf files
   local env = os_setenv .. " TEXMFCNF=." .. os_pathsep
   local localtexmf = ""
@@ -80,7 +80,7 @@ function biber(name,dir)
 end
 
 function bibtex(name,dir)
-  local dir = dir or "."
+  dir = dir or "."
   if fileexists(dir .. "/" .. name .. ".aux") then
     -- LaTeX always generates an .aux file, so there is a need to
     -- look inside it for a \citation line
@@ -105,7 +105,7 @@ function bibtex(name,dir)
 end
 
 function makeindex(name,dir,inext,outext,logext,style)
-  local dir = dir or "."
+  dir = dir or "."
   if fileexists(dir .. "/" .. name .. inext) then
     if style == "" then style = nil end
     return runcmd(makeindexexe .. " " .. makeindexopts
@@ -119,15 +119,15 @@ function makeindex(name,dir,inext,outext,logext,style)
 end
 
 function tex(file,dir,cmd)
-  local dir = dir or "."
-  local cmd = cmd or typesetexe .. typesetopts
+  dir = dir or "."
+  cmd = cmd or typesetexe .. typesetopts
   return runcmd(cmd .. " \"" .. typesetcmds
     .. "\\input " .. file .. "\"",
     dir,{"TEXINPUTS","LUAINPUTS"})
 end
 
 local function typesetpdf(file,dir)
-  local dir = dir or "."
+  dir = dir or "."
   local name = jobname(file)
   print("Typesetting " .. name)
   local fn = typeset
@@ -141,7 +141,7 @@ local function typesetpdf(file,dir)
     print(" ! Compilation failed")
     return errorlevel
   end
-  pdfname = name .. pdfext
+  local pdfname = name .. pdfext
   rm(docfiledir,pdfname)
   return cp(pdfname,dir,docfiledir)
 end
@@ -226,7 +226,7 @@ function doc(files)
             end
             -- Now know if we should typeset this source
             if typeset then
-              local errorlevel = typesetpdf(srcname,path)
+              errorlevel = typesetpdf(srcname,path)
               if errorlevel ~= 0 then
                 return errorlevel
               else

--- a/l3build-typesetting.lua
+++ b/l3build-typesetting.lua
@@ -38,7 +38,7 @@ local os_type = os.type
 function dvitopdf(name, dir, engine, hide)
   run(
     dir,
-    set_epoch_cmd(epoch) ..
+    set_epoch_cmd(epoch, forcecheckepoch) ..
     "dvips " .. name .. dviext
       .. (hide and (" > " .. os_null) or "")
       .. os_concat ..
@@ -68,7 +68,7 @@ function runcmd(cmd,dir,vars)
   for _,var in pairs(vars) do
     env = env .. os_concat .. os_setenv .. " " .. var .. "=" .. envpaths
   end
-  return run(dir,set_epoch_cmd(epoch) .. env .. os_concat .. cmd)
+  return run(dir,set_epoch_cmd(epoch, forcedocepoch) .. env .. os_concat .. cmd)
 end
 
 function biber(name,dir)

--- a/l3build-unpack.lua
+++ b/l3build-unpack.lua
@@ -22,8 +22,6 @@ for those people who are interested.
 
 --]]
 
-local execute          = os.execute
-
 -- Unpack the package files using an 'isolated' system: this requires
 -- a copy of the 'basic' DocStrip program, which is used then removed
 function unpack(sources, sourcedirs)

--- a/l3build-upload.lua
+++ b/l3build-upload.lua
@@ -254,14 +254,6 @@ function construct_ctan_post(uploadfile,debug)
   ctan_field("uploader",     uploadconfig.uploader,      255, "Name of uploader",                    true,  false )
   ctan_field("version",      uploadconfig.version,        32, "Package version",                     true,  false )
 
-  --[=[ `qq` is unused because line 258 is commented
-  -- finish constructing the curl command:
-  local qq = '"'
-  if os_type == "windows" then
-    qq = '\"'
-  end
-  --]=]
--- commandline   ctan_post = ctan_post .. ' --form ' .. qq .. 'file=@' .. tostring(uploadfile) .. ';filename=' .. tostring(uploadfile) .. qq
   ctan_post = ctan_post .. '\nform="file=@' .. tostring(uploadfile) .. ';filename=' .. tostring(uploadfile) .. '"'
 
   return ctan_post

--- a/l3build-upload.lua
+++ b/l3build-upload.lua
@@ -78,6 +78,12 @@ end
 -- if upload is anything else, the user will be prompted whether to upload.
 -- For now, this is undocumented. I think I would prefer to keep it always set to ask for the time being.
 
+local ctan_post -- this is private to the module
+
+-- TODO: next is a public global method,
+-- but following functions are semantically local
+-- despite they are declared globally.
+
 function upload(tagnames)
 
   local uploadfile = ctanzip..".zip"
@@ -100,7 +106,7 @@ function upload(tagnames)
 
   uploadconfig.note =   uploadconfig.note  or file_contents(uploadconfig.note_file)
 
-  local tagnames = tagnames or { }
+  tagnames = tagnames or { }
   uploadconfig.version = tagnames[1] or uploadconfig.version
 
   local override_update_check = false
@@ -214,7 +220,7 @@ end
 
 function shell(s)
   local h = assert(popen(s, 'r'))
-  t = assert(h:read('*a'))
+  local t = assert(h:read('*a'))
   h:close()
   return t
 end
@@ -248,11 +254,13 @@ function construct_ctan_post(uploadfile,debug)
   ctan_field("uploader",     uploadconfig.uploader,      255, "Name of uploader",                    true,  false )
   ctan_field("version",      uploadconfig.version,        32, "Package version",                     true,  false )
 
+  --[=[ `qq` is unused because line 258 is commented
   -- finish constructing the curl command:
   local qq = '"'
   if os_type == "windows" then
     qq = '\"'
   end
+  --]=]
 -- commandline   ctan_post = ctan_post .. ' --form ' .. qq .. 'file=@' .. tostring(uploadfile) .. ';filename=' .. tostring(uploadfile) .. qq
   ctan_post = ctan_post .. '\nform="file=@' .. tostring(uploadfile) .. ';filename=' .. tostring(uploadfile) .. '"'
 
@@ -352,7 +360,7 @@ function file_contents (filename)
     local f= open(filename,"r")
     if f==nil then
       return nil
-    else 
+    else
       local s = f:read("*all")
       close(f)
       return s

--- a/l3build-variables.lua
+++ b/l3build-variables.lua
@@ -220,7 +220,6 @@ test_types = setmetatable(test_types or {}, { __index = {
       test = pvtext,
       generated = pdfext,
       reference = tpfext,
-      compare = compare_pdf,
       rewrite = rewrite_pdf,
    },
 }})

--- a/l3build-variables.lua
+++ b/l3build-variables.lua
@@ -207,6 +207,25 @@ pvtext = pvtext or ".pvt"
 tlgext = tlgext or ".tlg"
 tpfext = tpfext or ".tpf"
 
+test_types = setmetatable(test_types or {}, { __index = {
+   log = {
+      test = lvtext,
+      generated = logext,
+      reference = tlgext,
+      expectation = lveext,
+      compare = compare_tlg,
+      rewrite = rewrite_log,
+   },
+   pdf = {
+      test = pvtext,
+      generated = pdfext,
+      reference = tpfext,
+      compare = compare_pdf,
+      rewrite = rewrite_pdf,
+   },
+}})
+test_order = test_order or {"log", "pdf"}
+
 -- Manifest options
 manifestfile = manifestfile or "MANIFEST.md"
 

--- a/l3build-variables.lua
+++ b/l3build-variables.lua
@@ -207,22 +207,22 @@ pvtext = pvtext or ".pvt"
 tlgext = tlgext or ".tlg"
 tpfext = tpfext or ".tpf"
 
-test_types = setmetatable(test_types or {}, { __index = {
-   log = {
-      test = lvtext,
-      generated = logext,
-      reference = tlgext,
-      expectation = lveext,
-      compare = compare_tlg,
-      rewrite = rewrite_log,
-   },
-   pdf = {
-      test = pvtext,
-      generated = pdfext,
-      reference = tpfext,
-      rewrite = rewrite_pdf,
-   },
-}})
+test_types = test_types or { }
+test_types.log = test_types.log or {
+  test = lvtext,
+  generated = logext,
+  reference = tlgext,
+  expectation = lveext,
+  compare = compare_tlg,
+  rewrite = rewrite_log,
+}
+test_types.pdf = test_types.pdf or {
+  test = pvtext,
+  generated = pdfext,
+  reference = tpfext,
+  rewrite = rewrite_pdf,
+}
+
 test_order = test_order or {"log", "pdf"}
 
 -- Manifest options

--- a/l3build.dtx
+++ b/l3build.dtx
@@ -320,8 +320,11 @@
 % which is read during execution. In the current release of \pkg{l3build},
 % \texttt{build.lua} is read automatically and can access all of the global
 % functions provided by the script. Thus it may contain a simple list of
-% variable settings \emph{or} additionally custom code to change the build
-% process. A number of example scripts are given in Section~\ref{sec:examples}.
+% variable settings \emph{or} additional code to customize the build
+% process.
+%
+%The required knowledge in Lua programing is largely covered by a small number of example scripts given in Section~\ref{sec:examples}.
+% For a more advanced usage, one may consult general Lua documentations including \url{http://www.lua.org/manual/5.3/manual.html} and for the few |texlua| specific additions see section 4.2 of the \LuaTeX{} manual available locally with |texdoc luatex| command line or at \url{https://www.pragma-ade.com/general/manuals/luatex.pdf}.
 %
 % \subsection{Main build targets}
 %

--- a/l3build.dtx
+++ b/l3build.dtx
@@ -340,11 +340,10 @@
 % \item install
 % \item manifest
 % \item save \meta{name(s)}
-% \item tag \meta{tag}
+% \item tag [\meta{tag name}]
 % \item uninstall
 % \item unpack
-% \item upload
-% \item upload \meta{tag}
+% \item upload [\meta{version}]
 % \end{itemize}
 % These targets are described below.
 %
@@ -563,17 +562,14 @@
 % Improvements to this process are planned for the future.
 % \end{buildcmd}
 %
-% \begin{buildcmd}{tag}
-% Modifies the contents of files specified by |tagfiles| using a search pattern
-% to automatically update the `release tag' (or package version) and date.
-% The tag is given as the command line option and the date using
-% |--date| (|-d|). If not given, the date will default to the current date in
-% ISO format (YYYY-MM-DD). If no option is given (i.e., no tag specified) the tag
-% is passed through as |nil| to allow setting the tag programmatically.
+% \begin{buildcmd}{tag [\meta{tag name}]}
+% Apply the Lua |update_tag()| function to modify the contents of files specified by |tagfiles| to update the `release tag' (or package version) and date.
+% The tag is given as the optional command line argument \meta{tag name} and the date using
+% |--date| (or |-d|). If not given, the date will default to the current date in
+% ISO format (YYYY-MM-DD). If no \meta{tag name} is given, the tag will default to |nil|.
+% Both are passed as arguments to the |update_tag()| function.
 %
-% The standard setup has no search pattern defined for this target and so no action
-% will be taken \emph{unless} tag substitution is set up by defining the Lua function
-% |update_tag()|. See Section~\ref{sec:tagging} for full details on this feature.
+% The standard setup does nothing unless tag update is set up by defining |update_tag()|. See Section~\ref{sec:tagging} for full details on this feature.
 % \end{buildcmd}
 %
 % \begin{buildcmd}{unpack}
@@ -588,11 +584,11 @@
 % By default this process allows files to be accessed in all standard |texmf| trees; this can be disabled by setting \var{unpacksearch} to |false|.
 % \end{buildcmd}
 %
-% \begin{buildcmd}{upload}
+% \begin{buildcmd}{upload [\meta{version}]}
 % This target uses \texttt{curl} to upload the package zip file (created using \texttt{ctan}) to CTAN.
 % To control the metadata used to upload the package, the \texttt{uploadconfig} table should be populated with a number of fields.
 % These are documented in Table~\ref{tab:upload-setup}.
-% Missing required fields will result in an interactive prompt for manual entry.
+% Missing required fields will result in an interactive prompt for manual entry. When given, \meta{version} overrides \texttt{uploadconfig.version}.
 %
 % See Section~\ref{sec:upload} for full details on this feature.
 % \end{buildcmd}
@@ -1294,7 +1290,7 @@
 % \label{sec:tagging}
 %
 % The |tag| target can automatically edit
-% source files to modify date and release tag. As standard, no automatic
+% source files to modify date and release tag name. As standard, no automatic
 % replacement takes place, but setting up a |update_tag()| function
 % will allow this to happen. This function takes four input arguments:
 % \begin{enumerate}[nosep]
@@ -1334,7 +1330,7 @@
 %
 % To allow more complex tasks to take place, a hook |tag_hook()| is also
 % available. It will receive the tag name and date as arguments, and
-% may be used to carry out arbitrary tasks after the main tagging process.
+% may be used to carry out arbitrary tasks after all files have been updated.
 % For example, this can be used to set a version control tag for an entire repository.
 %
 %

--- a/l3build.dtx
+++ b/l3build.dtx
@@ -692,10 +692,10 @@
 % \subsection{Selective running of tests}
 %
 % The variables |includetests| and |excludetests| may be used to select which
-% tests are run: these variables take test \emph{names} not full file names.
+% tests are run: these variables take raw test \emph{names} not full file names.
 % The list of tests in |excludetests| overrides any matches in |includetests|,
 % meaning that tests can be disabled selectively. It also makes it possible
-% to disable test on for example a platform basis: the Lua core variable
+% to disable test on for example a platform basis: the |texlua| specific variable
 % |os.type| may be used to set |excludetests| only on some systems.
 %
 % \subsection{Multiple sets of tests}

--- a/l3build.dtx
+++ b/l3build.dtx
@@ -114,8 +114,8 @@
 \luavarset{stdengine}    {"pdftex"}{Engine to generate \texttt{.tlg} file from}
 \luavarset{checkformat}  {"latex"} {Format to use for tests}
 \luavarset{specialformats}{\meta{table}} {Non-standard engine/format combinations}
-\luavarset{test_types}        {\meta{table}} {Custom test variants}
-\luavarset{test_order}        {\{"log", "pdf"\}} {Which kinds of tests to evaluate}
+\luavarset{\detokenize{test_types}}        {\meta{table}} {Custom test variants}
+\luavarset{\detokenize{test_order}}        {\{"log", "pdf"\}} {Which kinds of tests to evaluate}
 \luavarseparator
 \luavarset{checkconfigs}{\{\}}{Configurations to use for tests}
 \luavarseparator

--- a/l3build.dtx
+++ b/l3build.dtx
@@ -569,7 +569,7 @@
 % ISO format (YYYY-MM-DD). If no \meta{tag name} is given, the tag will default to |nil|.
 % Both are passed as arguments to the |update_tag()| function.
 %
-% The standard setup does nothing unless tag update is set up by defining |update_tag()|. See Section~\ref{sec:tagging} for full details on this feature.
+% The standard setup does nothing unless tag update is set up by defining a custom |update_tag()| function. See Section~\ref{sec:tagging} for full details on this feature.
 % \end{buildcmd}
 %
 % \begin{buildcmd}{unpack}

--- a/l3build.dtx
+++ b/l3build.dtx
@@ -114,6 +114,8 @@
 \luavarset{stdengine}    {"pdftex"}{Engine to generate \texttt{.tlg} file from}
 \luavarset{checkformat}  {"latex"} {Format to use for tests}
 \luavarset{specialformats}{\meta{table}} {Non-standard engine/format combinations}
+\luavarset{test_types}        {\meta{table}} {Custom test variants}
+\luavarset{test_order}        {\{"log", "pdf"\}} {Which kinds of tests to evaluate}
 \luavarseparator
 \luavarset{checkconfigs}{\{\}}{Configurations to use for tests}
 \luavarseparator
@@ -1245,6 +1247,38 @@
 % engine-specific, thus one |.tpf| file should be stored per engine to be
 % tested.
 %
+% \subsection{Custom tests}
+%
+% If neither the text-based methods nor PDF-based tests are sufficient,
+% there is the additional option of defining custom variants with individual
+% normalization rules.
+%
+% For this, the variant has to be registered in the \texttt{test_types} table
+% and then activated in \texttt{test_order}.
+%
+% Every element in \texttt{test_types} is a table with fields \texttt{test}
+% (the extension of the test file), \texttt{reference} (the extension of the
+% file the output is compared with), \texttt{generated} (extension of the
+% analyzed \LaTeX{} output file) and \texttt{rewrite} (A Lua function for
+% normalizing the output file, taking as parameters the name of the unnormalized
+% \LaTeX{} output file to be read, the name of the normalized file to be written,
+% the engine name and a potential errorcode).
+%
+% For example:
+% \begin{verbatim}
+% test_types = {
+%   mytest = {
+%     test = ".mylvt",
+%     reference = ".mytlg",
+%     generated = ".log",
+%     rewrite = function(source, normalized, engine, errorcode)
+%       -- In this example we just copy the logfile without any normalization
+%       os.execute(string.format("cp %s %s", source, normalized)
+%     end,
+%   },
+% }
+% test_order = {"mylvt", "log", "pdf"}
+% \end{verbatim}
 %
 % \section{Release-focussed features}
 %

--- a/l3build.dtx
+++ b/l3build.dtx
@@ -323,7 +323,7 @@
 % variable settings \emph{or} additional code to customize the build
 % process.
 %
-%The required knowledge in Lua programing is largely covered by a small number of example scripts given in Section~\ref{sec:examples}.
+%The example scripts given in Section~\ref{sec:examples} largely cover the required knowledge in Lua programing.
 % For a more advanced usage, one may consult general Lua documentations including \url{http://www.lua.org/manual/5.3/manual.html} and for the few |texlua| specific additions see section 4.2 of the \LuaTeX{} manual available locally with |texdoc luatex| command line or at \url{https://www.pragma-ade.com/general/manuals/luatex.pdf}.
 %
 % \subsection{Main build targets}

--- a/l3build.lua
+++ b/l3build.lua
@@ -24,50 +24,205 @@ for those people who are interested.
 
 --]]
 
+print("DEVELOPMENT: REFACTOR BRANCH")
+
 -- Version information
 release_date = "2020-06-04"
 
--- File operations are aided by the LuaFileSystem module
-local lfs = require("lfs")
-
 -- Local access to functions
 
-local assert           = assert
-local ipairs           = ipairs
-local insert           = table.insert
-local lookup           = kpse.lookup
-local match            = string.match
-local gsub             = string.gsub
-local next             = next
-local print            = print
-local select           = select
-local tonumber         = tonumber
-local exit             = os.exit
+local assert  = assert
+local ipairs  = ipairs
+local append  = table.insert
+local match   = string.match
+local gmatch  = string.gmatch
+local gsub    = string.gsub
+local next    = next
+local print   = print
+local exit    = os.exit
 
--- l3build setup and functions
+local kpse = require("kpse")
 kpse.set_program_name("kpsewhich")
-build_kpse_path = match(lookup("l3build.lua"),"(.*[/])")
-local function build_require(s)
-  require(lookup("l3build-"..s..".lua", { path = build_kpse_path } ) )
+
+-- # Start of the booting process
+
+local is_main  -- Whether the script is called first
+local work_dir -- the directory containing "build.lua" and friends
+
+assert(not _G.l3build, "No self call")
+
+---@alias flag_table_t table<string, boolean>
+
+---@class l3build_t
+---@field debug flag_table_t the special --debug-foo CLI arguments
+---@field PACKAGE string "l3build", `package.loaded` key
+---@field NAME string "l3build", display name
+---@field PATH string synonym of `launch_dir` .. "/l3build.lua"
+---@field work_dir string where the "build.lua" lives
+---@field launch_dir string where "l3build.lua" and friends live
+---@field start_dir string the current directory at load time
+local l3build = { -- global data available as package.
+  debug = {} -- storage for special debug flags (private UI)
+}
+
+do
+  -- the directory containing "l3build.lua" by kpse
+  local kpse_dir = match(kpse.lookup("l3build.lua"), ".*/")
+
+  -- Setup dirs where require will look for modules.
+
+  local launch_dir -- the directory containing "l3build.lua"
+
+  -- File operations are aided by the LuaFileSystem module
+  local lfs = require("lfs")
+
+  local start_dir = lfs.currentdir() .. "/" -- this is the current dir at launch time
+
+  ---Extract dir and base from path
+  ---@param path string
+  ---@return string dir includes a trailing '/', defaults to "./"
+  ---@return string base
+  local function to_dir_base(path)
+    local dir, base = match(path, "(.*/)(.*)")
+    if not dir then dir, base = "./", path end
+    return dir, base
+  end
+
+  ---Central function to allow launching l3build from a subdirectory
+  ---of a local repository.
+  ---Find `base` in `dir` or one of its parents, returns the container.
+  ---We do not assume that `dir` contains no ".." component
+  ---such that we cannot use `to_dir_base`.
+  ---Instead we append `/..` and rely on lua to do the job.
+  ---The max number of trials is the number of components
+  ---of the absolute path of `dir`, which majorated in the for loop
+  ---Intermediate directories must exist.
+  ---@param dir string must end with '/'
+  ---@param base string relative file or directory name
+  ---@return string|nil dir ends with '/' when non nil
+  local function container(dir, base)
+    for _ in gmatch(dir .. lfs.currentdir(), "[^/]+") do
+      local p = dir .. base
+      if os.rename(p, p) then return dir end -- true iff file or dir at the given path
+      -- synonym of previous line:
+      -- if package.searchpath("?", p, "", "") then return dir end
+      dir = dir .. "../"
+    end
+  end
+
+  local cmd_path = arg[0]
+  local cmd_dir, cmd_base = to_dir_base(cmd_path)
+
+  is_main = cmd_base == "l3build" or cmd_base == "l3build.lua"
+  assert(is_main == not not (match(arg[0], "l3build$") or match(arg[0], "l3build%.lua$")))
+  -- l3b_dir:
+  if cmd_base == "l3build.lua" then -- `texlua foo/bar/l3build.lua ...`
+    launch_dir = cmd_dir
+  else
+    launch_dir = container('./', "l3build.lua") or kpse_dir
+  end
+
+  -- work_dir:
+  if cmd_base == "build.lua" then
+    work_dir = cmd_dir
+  else
+    work_dir = container(cmd_dir, "build.lua") or container(start_dir, "build.lua")
+    if not work_dir then
+      print(arg[0])
+      print("  start:  ".. start_dir)
+      -- print("  work:   ".. work_dir)
+      print("  kpse:   ".. kpse_dir)
+      print("  launch: ".. launch_dir)
+      local dir, base = start_dir, "build.lua"
+      for _ in gmatch(dir .. lfs.currentdir(), "[^/]+") do
+        local p = dir .. base
+        print(p)
+        if os.rename(p, p) then return dir end -- true iff file or dir at the given path
+        dir = dir .. "../"
+      end
+    end
+    assert(work_dir, 'Error: Cannot find configuration file "build.lua"')
+  end
+
+  ---Register the given pakage.
+  ---Lua's require function return either true or a table.
+  ---Here we always return a table.
+  ---@param pkg table|boolean
+  ---@param pkg_name string key in `package.loaded`
+  ---@param name string display name
+  ---@param path string
+  local function register(pkg, pkg_name, name, path)
+    if type(pkg) ~= "table" then pkg = {} end
+    package.loaded[pkg_name] = pkg
+    pkg.PACKAGE = pkg_name
+    pkg.NAME = name
+    pkg.PATH = path
+    return pkg
+  end
+
+  l3build.work_dir = work_dir
+  l3build.start_dir = start_dir
+  l3build.launch_dir = launch_dir
+
+  register(l3build, "l3build", "l3build", launch_dir .. "l3build.lua")
+
+  local require_orig = require
+  ---Overwrites global `require`.
+  ---When `pkg_name` is "l3b.<name>",
+  ---looks for "<l3b_dir>l3build-<name>.lua".
+  ---@param pkg_name string
+  ---@return table|boolean
+  function require(pkg_name)
+    local result = package.loaded[pkg_name]
+    if result then return result end -- recursive calls will end here
+    local name = match(pkg_name, "^l3b%.(.*)")
+    if name then
+      package.loaded[pkg_name] = true
+      local path = launch_dir .. "l3build-"..name
+      result = require_orig(path) -- error here if no such module exists
+      package.loaded[path] = nil  -- change the registration name
+      result = register(result, pkg_name, name, path .. ".lua")
+    else
+      -- forthcoming management here
+      result = require_orig(pkg_name)
+    end
+    if l3build.debug.require then
+      print("DEBUG Info: package required ".. pkg_name, result.PATH)
+    end
+    return result
+  end
+
+  for _,o in ipairs(arg) do
+    if match(o, "^%-%-debug") then
+      print("l3build: A testing and building system for LaTeX")
+      print("  start:  ".. start_dir)
+      print("  work:   ".. work_dir)
+      print("  kpse:   ".. kpse_dir)
+      print("  launch: ".. launch_dir)
+      print()
+    end
+  end
+
 end
+--[=[ end of booting process ]=]
 
 -- Minimal code to do basic checks
-build_require("arguments")
-build_require("help")
+require("l3b.arguments")
+require("l3b.help")
 
-build_require("file-functions")
-build_require("typesetting")
-build_require("aux")
-build_require("clean")
-build_require("check")
-build_require("ctan")
-build_require("install")
-build_require("unpack")
-build_require("manifest")
-build_require("manifest-setup")
-build_require("tagging")
-build_require("upload")
-build_require("stdmain")
+require("l3b.file-functions")
+require("l3b.typesetting")
+require("l3b.aux")
+require("l3b.clean")
+require("l3b.check")
+require("l3b.ctan")
+require("l3b.install")
+require("l3b.unpack")
+require("l3b.manifest")
+require("l3b.manifest-setup")
+require("l3b.tagging")
+require("l3b.upload")
+require("l3b.stdmain")
 
 -- This has to come after stdmain(),
 -- and that has to come after the functions are defined
@@ -83,19 +238,14 @@ end
 main = main or stdmain
 
 -- Load configuration file if running as a script
-if match(arg[0], "l3build$") or match(arg[0], "l3build%.lua$") then
+if is_main then
   -- Look for some configuration details
-  if fileexists("build.lua") then
-    dofile("build.lua")
-  else
-    print("Error: Cannot find configuration build.lua")
-    exit(1)
-  end
+  dofile(work_dir .. "build.lua")
 end
 
 -- Load standard settings for variables:
 -- comes after any user versions
-build_require("variables")
+require("l3b.variables")
 
 -- Ensure that directories are 'space safe'
 maindir       = escapepath(maindir)
@@ -139,17 +289,17 @@ end
 
 if options["target"] == "check" then
   if #checkconfigs > 1 then
-    local errorlevel = 0
-    local opts = options
+    local error_level = 0
+    local opts = options -- TODO: remove this shallow copy
     local failed = { }
-    for i = 1, #checkconfigs do
-      opts["config"] = {checkconfigs[i]}
-      errorlevel = call({"."}, "check", opts)
-      if errorlevel ~= 0 then
+    for _, config in ipairs(checkconfigs) do
+      opts["config"] = { config }
+      error_level = call({"."}, "check", opts)
+      if error_level ~= 0 then
         if options["halt-on-error"] then
           exit(1)
         else
-          insert(failed,checkconfigs[i])
+          append(failed, config)
         end
       end
     end
@@ -161,7 +311,7 @@ if options["target"] == "check" then
         if config ~= "build" then
           testdir = testdir .. "-" .. config
         end
-        for _,i in ipairs(filelist(testdir,"*" .. os_diffext)) do
+        for _,i in ipairs(filelist(testdir, "*" .. os_diffext)) do
           print("  - " .. testdir .. "/" .. i)
         end
         print("")
@@ -173,21 +323,22 @@ if options["target"] == "check" then
     end
   end
 end
+local config_1 = checkconfigs[1]
 if #checkconfigs == 1 and
-   checkconfigs[1] ~= "build" and
+   config_1 ~= "build" and
    (options["target"] == "check" or options["target"] == "save" or options["target"] == "clean") then
-   local config = "./" .. gsub(checkconfigs[1],".lua$","") .. ".lua"
+   local config = work_dir .. gsub(config_1, ".lua$","") .. ".lua"
    if fileexists(config) then
      local savedtestfiledir = testfiledir
      dofile(config)
-     testdir = testdir .. "-" .. checkconfigs[1]
+     testdir = testdir .. "-" .. config_1
      -- Reset testsuppdir if required
      if savedtestfiledir ~= testfiledir and
        testsuppdir == savedtestfiledir .. "/support" then
        testsuppdir = testfiledir .. "/support"
      end
    else
-     print("Error: Cannot find configuration " ..  checkconfigs[1])
+     print("Error: Cannot find configuration " .. config_1)
      exit(1)
    end
 end


### PR DESCRIPTION
Dear maintainers

Here is my first refactor PR.

latex2e checks pass but I did not test a full install.

When reviews are complete, please merge this PR into a newly created **refactor** branch.
Each time l3build is launched, it starts by printing "DEVELOPMENT: REFACTOR BRANCH" to the console.

**This print statement should be removed when merging to master.**

This is a little bit more than a refactor because of some private CLI additions.

### Bug fix

There is a typo: no `os_time` global variable in Lua.

### new `l3build` package

`local l3build = require("l3build")` allows to shared data without polluting the global space.

### boot section

`l3build.lua` is reorganized to first setup the running context. Main tasks are

- find where the `build.lua` lives
- find where the `l3build.lua` lives
- redefine `require`

The `build.lua` was expected in the current directory, now it can also be in any parent of the current directory.
The `l3build.lua` was expected in the locations used by `kpse`, now it starts by checking the current directory and any of its parents then use `kpse` on failure.

This is how `l3build` can be launched from anywhere below a local repository.
Also this is how an `l3build` development version can be used, without being installed first.
Exception for `latex2e` because of hard coded paths.

### `require` revisited: `build_require("arguments")`→ `require("l3b.arguments")`

Any first call to `require("l3b.<foo>")` will load the "l3build-\<foo\>.lua" located where `l3build.lua` lives.
Subsequent calls will return the loaded object.

This prepares a more explicit file dependency also useful when unit testing l2build itself.

Any l3build loaded module records its own package name, display name and path.

When the package name is not "l3b.<foo>", the standard `texlua` is used.

### New private debug flags

#### debug banner
If one of the CLI options is "--debug*" then next diagnostic banner is displayed first.
For example, from the `testfiles` folder, the output of
```
texlua ../l3build.lua version --debug
```
reads
```
DEVELOPMENT: REFACTOR BRANCH
l3build: A testing and building system for LaTeX
  start:  /.../l3build/testfiles/
  work:   ../
  kpse:   /usr/local/texlive/2020/texmf-dist/scripts/l3build/
  launch: ../


l3build: A testing and building system for LaTeX

Release 2020-06-04
Copyright (C) 2014-2020 The LaTeX Project
```
The `launch` directory is where all the l3build scripts are located.
The `work` directory is where the `build.lua` is located.

#### debug require

With `--debug-require` CLI options, additional info is displayed each time a new l3build module is required.
For example, from the `testfiles` folder, the output of
```
texlua ../l3build.lua uninstall --debug-require
```
partly reads

```
...
DEBUG Info: package required l3b.arguments	../l3build-arguments.lua
DEBUG Info: package required l3b.help	../l3build-help.lua
...
```

#### Other debug flags

Any other `--debug-<foo>` results in `l3build.debug[<foo>] == true`.
This allows some conditional code chunks.
For example, on can print dedicated debug diagnostic on certain user demand only.

#### Inheritance

Actually the design is shallow in the sense that it is not forwarded to subprocesses launched by `call`.
This is to avoid too many printed messages.

When refactoring "arguments" I will use a `--debug-<foo>` and `--debug-deep-<foo>` approach,
where only deep flags pass through `call`.



