### PR TITLE
Bug fix in tex command

### DIFF
--- a/l3build-typesetting.lua
+++ b/l3build-typesetting.lua
@@ -120,7 +120,7 @@ end
 
 function tex(file,dir,cmd)
   dir = dir or "."
-  cmd = cmd or typesetexe .. typesetopts
+  cmd = cmd or typesetexe .. " " .. typesetopts
   return runcmd(cmd .. " \"" .. typesetcmds
     .. "\\input " .. file .. "\"",
     dir,{"TEXINPUTS","LUAINPUTS"})


### PR DESCRIPTION
Missing space to separate the command and the arguments