### PR TITLE
Fix issue #182

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ this project uses date-based 'snapshot' version identifiers.
 
 - Normal Lua function calls (issue #127)
 
+### Fixed
+
+- the home texmf directory is now created before use
+- the yyyy-mm-dd format of epoch caused a  crashed
+
 ## [2020-06-04]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,7 @@ this project uses date-based 'snapshot' version identifiers.
 
 ### Fixed
 
-- the home texmf directory is now created before use
-- the yyyy-mm-dd format of epoch caused a  crashed
+- installation now supports deeper directory levels (issue #182) 
 
 ## [2020-06-04]
 

--- a/l3build-ctan.lua
+++ b/l3build-ctan.lua
@@ -38,12 +38,12 @@ function copyctan()
       end
     else
       for _,filetype in pairs(files) do
-        for file,_ in pairs(tree(source,filetype)) do
-          local path = dirname(file)
+        for _,p in ipairs(tree(source,filetype)) do
+          local path = dirname(p.src)
           local ctantarget = ctandir .. "/" .. ctanpkg .. "/"
             .. source .. "/" .. path
           mkdir(ctantarget)
-          cp(file,source,ctantarget)
+          cp(p.src,source,ctantarget)
         end
       end
     end

--- a/l3build-file-functions.lua
+++ b/l3build-file-functions.lua
@@ -300,7 +300,7 @@ end
 ---@param src_path string
 ---@param glob string
 ---@return table<integer,tree_entry_t>
-local function tree(src_path, glob)
+function tree(src_path, glob)
   local function cropdots(path)
     return path:gsub( "^%./", ""):gsub("/%./", "/")
   end

--- a/l3build-install.lua
+++ b/l3build-install.lua
@@ -68,15 +68,15 @@ function uninstall()
   -- Any script man files need special handling
   local manfiles = { }
   for _,glob in pairs(scriptmanfiles) do
-    for file,_ in pairs(tree(docfiledir,glob)) do
+    for _,p in ipairs(tree(docfiledir,glob)) do
       -- Man files should have a single-digit extension: the type
-      local installdir = gethome() .. "/doc/man/man"  .. match(file,".$")
-      if fileexists(installdir .. "/" .. file) then
+      local installdir = gethome() .. "/doc/man/man"  .. match(p.src,".$")
+      if fileexists(installdir .. "/" .. p.src) then
         if options["dry-run"] then
-          insert(manfiles,"man" .. match(file,".$") .. "/" ..
-           select(2,splitpath(file)))
+          insert(manfiles,"man" .. match(p.src,".$") .. "/" ..
+           select(2,splitpath(p.src)))
         else
-          errorlevel = errorlevel + rm(installdir,file)
+          errorlevel = errorlevel + rm(installdir,p.src)
         end
       end
     end
@@ -127,9 +127,9 @@ function install_files(target,full,dry_run)
     -- Generate a file list and include the directory
     for _,glob_table in pairs(files) do
       for _,glob in pairs(glob_table) do
-        for file,_ in pairs(tree(source,glob)) do
+        for _,p in ipairs(tree(source,glob)) do
           -- Just want the name
-          local path,filename = splitpath(file)
+          local path,filename = splitpath(p.src)
           local sourcepath = "/"
           if path == "." then
             sourcepaths[filename] = source
@@ -161,7 +161,8 @@ function install_files(target,full,dry_run)
     -- The target is only created if there are actual files to install
     if next(filenames) then
       if not dry_run then
-        for _,path in pairs(paths) do
+        for i = #paths, 1, -1 do
+          local path = paths[i]
           local target_path = target .. "/" .. path
           if not cleanpaths[target_path] then
             errorlevel = cleandir(target_path)
@@ -194,16 +195,16 @@ function install_files(target,full,dry_run)
       local excludelist = { }
       for _,glob_table in pairs(exclude) do
         for _,glob in pairs(glob_table) do
-          for file,_ in pairs(tree(dir,glob)) do
-            excludelist[file] = true
+          for _,p in ipairs(tree(dir,glob)) do
+            excludelist[p.src] = true
           end
         end
       end
       local result = { }
       for _,glob in pairs(include) do
-        for file,_ in pairs(tree(dir,glob)) do
-          if not excludelist[file] then
-            insert(result, file)
+        for _,p in ipairs(tree(dir,glob)) do
+          if not excludelist[p.src] then
+            insert(result, p.src)
           end
         end
       end
@@ -255,15 +256,15 @@ function install_files(target,full,dry_run)
     -- Any script man files need special handling
     local manfiles = { }
     for _,glob in pairs(scriptmanfiles) do
-      for file,_ in pairs(tree(docfiledir,glob)) do
+      for _,p in ipairs(tree(docfiledir,glob)) do
         if dry_run then
-          insert(manfiles,"man" .. match(file,".$") .. "/" ..
-            select(2,splitpath(file)))
+          insert(manfiles,"man" .. match(p.src,".$") .. "/" ..
+            select(2,splitpath(p.src)))
         else
           -- Man files should have a single-digit extension: the type
-          local installdir = target .. "/doc/man/man"  .. match(file,".$")
+          local installdir = target .. "/doc/man/man"  .. match(p.src,".$")
           errorlevel = errorlevel + mkdir(installdir)
-          errorlevel = errorlevel + cp(file,docfiledir,installdir)
+          errorlevel = errorlevel + cp(p.src,docfiledir,installdir)
         end
       end
     end

--- a/l3build-install.lua
+++ b/l3build-install.lua
@@ -161,8 +161,7 @@ function install_files(target,full,dry_run)
     -- The target is only created if there are actual files to install
     if next(filenames) then
       if not dry_run then
-        for i = #paths, 1, -1 do
-          local path = paths[i]
+        for _,path in ipairs(paths) do
           local target_path = target .. "/" .. path
           if not cleanpaths[target_path] then
             errorlevel = cleandir(target_path)

--- a/l3build-tagging.lua
+++ b/l3build-tagging.lua
@@ -71,8 +71,8 @@ function tag(tagnames)
   local errorlevel = 0
   for _,dir in pairs(dirs) do
     for _,filetype in pairs(tagfiles) do
-      for file,_ in pairs(tree(dir,filetype)) do
-        errorlevel = update_file_tag(dir .. "/" .. file,tagname,tagdate)
+      for _,p in ipairs(tree(dir,filetype)) do
+        errorlevel = update_file_tag(dir .. "/" .. p.src,tagname,tagdate)
         if errorlevel ~= 0 then
           return errorlevel
         end

--- a/l3build-typesetting.lua
+++ b/l3build-typesetting.lua
@@ -209,8 +209,8 @@ function doc(files)
   for _,typesetfiles in ipairs({typesetdemofiles,typesetfiles}) do
     for _,glob in pairs(typesetfiles) do
       for _,dir in ipairs({typesetdir,unpackdir}) do
-        for _,file in pairs(tree(dir,glob)) do
-          local path,srcname = splitpath(file)
+        for _,p in ipairs(tree(dir,glob)) do
+          local path,srcname = splitpath(p.cwd)
           local name = jobname(srcname)
           if not done[name] then
             local typeset = true

--- a/l3build-unpack.lua
+++ b/l3build-unpack.lua
@@ -70,8 +70,8 @@ bundleunpack = bundleunpack or function(sourcedirs, sources)
     end
   end
   for _,i in ipairs(unpackfiles) do
-    for j,_ in pairs(tree(unpackdir, i)) do
-      local path, name = splitpath(j)
+    for _,p in ipairs(tree(unpackdir, i)) do
+      local path, name = splitpath(p.src)
       local localdir = abspath(localdir)
       local success = io.popen(
         "cd " .. unpackdir .. "/" .. path .. os_concat ..


### PR DESCRIPTION
- `tree` in file functions is ordered in deep first traversal. At a given level, the order is given by `lfs.dir`.
- cleandir is made in reverse order in install
- in clean the rm is also in reverse order (and more efficient)
- some return values are fixed
- more efficient usage of lfs.attributes

Some review is needed before deeper tests