### PR TITLE
No more off-by-one error in recent LuaTeX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ this project uses date-based 'snapshot' version identifiers.
 
 - the home texmf directory is now created before use
 - the yyyy-mm-dd format of epoch caused a  crashed
+- no longer expect LuaTeX line lengths to be off by a character for new
+  LuaTeX versions
 
 ## [2020-06-04]
 

--- a/l3build-check.lua
+++ b/l3build-check.lua
@@ -102,7 +102,7 @@ end
 -- the 'business' part from the tests and removes system-dependent stuff
 local function normalize_log(content,engine,errlevels)
   local maxprintline = maxprintline
-  if match(engine,"^lua") or match(engine,"^harf") then
+  if (match(engine,"^lua") or match(engine,"^harf")) and luatex_version < 113 then
     maxprintline = maxprintline + 1 -- Deal with an out-by-one error
   end
   local function killcheck(line)


### PR DESCRIPTION
Don't adjust the maxlinelength if LuaTeX is sufficiently new.