### PR TITLE
Normalize paren based PDF IDs

### DIFF
--- a/l3build-check.lua
+++ b/l3build-check.lua
@@ -548,6 +548,7 @@ local function normalize_pdf(content)
       not match(line,"^%%%%Invocation") and
       not match(line,"^%%%%%+") then
       line = gsub(line,"%/ID( ?)%[<[^>]+><[^>]+>]","/ID%1[<ID-STRING><ID-STRING>]")
+      line = gsub(line,"%/ID( ?)%[(%b())%2%]","/ID%1[<ID-STRING><ID-STRING>]")
       new_content = new_content .. line .. os_newline
     end
   end


### PR DESCRIPTION
Should fix #203, but testing this is complicated since it's not easily reproducible.