### PR TITLE
Always typeset in typesetdir

### DIFF
--- a/.github/tl_packages
+++ b/.github/tl_packages
@@ -33,6 +33,7 @@ gettitlestring
 graphics
 hologo
 hycolor
+hypdoc
 iftex
 intcalc
 kvdefinekeys

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ this project uses date-based 'snapshot' version identifiers.
 
 ### Fixed
 - Allow config names ending with 'lua', as long as they don't end with '.lua'
+- All documentation files are build in a consistent environment with support
+  files visible.
 
 ## [2021-08-28]
 

--- a/l3build-typesetting.lua
+++ b/l3build-typesetting.lua
@@ -211,32 +211,32 @@ function doc(files)
   local done = {}
   for _,typesetfiles in ipairs({typesetdemofiles,typesetfiles}) do
     for _,glob in pairs(typesetfiles) do
-        for _,p in ipairs(tree(typesetdir,glob)) do
-          local path,srcname = splitpath(p.cwd)
-          local name = jobname(srcname)
-          if not done[name] then
-            local typeset = true
-            -- Allow for command line selection of files
-            if files and next(files) then
-              typeset = false
-              for _,file in pairs(files) do
-                if name == file then
-                  typeset = true
-                  break
-                end
-              end
-            end
-            -- Now know if we should typeset this source
-            if typeset then
-              errorlevel = typesetpdf(srcname,path)
-              if errorlevel ~= 0 then
-                return errorlevel
-              else
-                done[name] = true
+      for _,p in ipairs(tree(typesetdir,glob)) do
+        local path,srcname = splitpath(p.cwd)
+        local name = jobname(srcname)
+        if not done[name] then
+          local typeset = true
+          -- Allow for command line selection of files
+          if files and next(files) then
+            typeset = false
+            for _,file in pairs(files) do
+              if name == file then
+                typeset = true
+                break
               end
             end
           end
+          -- Now know if we should typeset this source
+          if typeset then
+            errorlevel = typesetpdf(srcname,path)
+            if errorlevel ~= 0 then
+              return errorlevel
+            else
+              done[name] = true
+            end
+          end
         end
+      end
     end
   end
   return 0

--- a/l3build-typesetting.lua
+++ b/l3build-typesetting.lua
@@ -174,7 +174,12 @@ end
 
 local function docinit()
   -- Set up
+  dep_install(typesetdeps)
+  unpack({sourcefiles, typesetsourcefiles}, {sourcefiledir, docfiledir})
   cleandir(typesetdir)
+  for _,file in pairs(typesetfiles) do
+    cp(file, unpackdir, typesetdir)
+  end
   for _,filetype in pairs(
       {bibfiles, docfiles, typesetfiles, typesetdemofiles}
     ) do
@@ -188,8 +193,6 @@ local function docinit()
   for _,file in pairs(typesetsuppfiles) do
     cp(file, supportdir, typesetdir)
   end
-  dep_install(typesetdeps)
-  unpack({sourcefiles, typesetsourcefiles}, {sourcefiledir, docfiledir})
   -- Main loop for doc creation
   local errorlevel = typeset_demo_tasks()
   if errorlevel ~= 0 then
@@ -208,8 +211,7 @@ function doc(files)
   local done = {}
   for _,typesetfiles in ipairs({typesetdemofiles,typesetfiles}) do
     for _,glob in pairs(typesetfiles) do
-      for _,dir in ipairs({typesetdir,unpackdir}) do
-        for _,p in ipairs(tree(dir,glob)) do
+        for _,p in ipairs(tree(typesetdir,glob)) do
           local path,srcname = splitpath(p.cwd)
           local name = jobname(srcname)
           if not done[name] then
@@ -235,7 +237,6 @@ function doc(files)
             end
           end
         end
-      end
     end
   end
   return 0


### PR DESCRIPTION
Suggested fix for #210: Instead of typesetting unpacked files directly in unpackdir, copy them to typesetdir first.

Additionally reorganizes the setup steps to ensure that we still prefer direct files over unpacked files if both match.