### PR TITLE
double backslashes when writing to curlopts file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ this project uses date-based 'snapshot' version identifiers.
 - Documentation improvements
 - Use `checkengines[1]` as the default for `stdengine`
 - Add sanity check for `TEXMFHOME` value
+- Double \ when writing the curl options, so that \ 
+  does not need to be doubled in note and announcement texts.
 
 ### Fixed
 - Installation of files when using MiKTeX (see #125)

--- a/l3build-upload.lua
+++ b/l3build-upload.lua
@@ -319,6 +319,7 @@ function ctan_single_field(fname,fvalue,max,desc,mandatory)
       if (max > 0 and len(vs) > max) then
         error("The field " .. fname .. " is longer than " .. max)
       end
+      vs = vs:gsub('\\','\\\\')
       vs = vs:gsub('"','\\"')
       vs = vs:gsub('`','\\`')
       vs = vs:gsub('\n','\\n')

--- a/l3build.dtx
+++ b/l3build.dtx
@@ -1525,7 +1525,8 @@
 % \meta{package}|-ctan.curlopt|. This is then passed to curl using its
 % |--config| commandline option.  (Using an intermediate file helps
 % keep \pkg{l3build} portable between systems using different
-% commandline quoting conventions.)
+% commandline quoting conventions. Any backslashes are doubled when writing 
+% to this file, so they do not need to be doubled in announcement and note texts.)
 %
 % By default the file is written into the current directory alongside
 % the zip file to be uploaded. You may wish to specify that this file


### PR DESCRIPTION
double up `\ `  when writing the curlopts file (leaving `\n` for newline etc) so you do not have to double `\ ` in files or on the terminal (in fields entered as Lua strings still need to use `\\ ` or use the `[[ ...]]`  unescaped string literals.)

This is a backwards incompatible change in that existing sumary or announcement strings will get doubled `\\ ` but announcememts at least are hopefully one-off strings not so this should not be too bad and at worst you get a slightly garbled message; the upload should still work.

