### PR TITLE
Run clean for all configurations by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ this project uses date-based 'snapshot' version identifiers.
 - Support for pre-constructed TDS-style sources (variable `tdsdirs`)
 - Support for injection of tokens using `specialformats`
 
+### Changed
+- If multiple configurations are present, let `l3build clean` run
+  on all of them by default. (issue #214)
+
 ## [2021-12-06]
 
 ### Fixed

--- a/l3build.lua
+++ b/l3build.lua
@@ -133,8 +133,8 @@ else
   checkconfigs = options["config"] or checkconfigs
 end
 
-if options["target"] == "check" then
-  if #checkconfigs > 1 then
+if #checkconfigs > 1 then
+  if options["target"] == "check" then
     local errorlevel = 0
     local opts = options
     local failed = { }
@@ -196,6 +196,13 @@ if options["target"] == "check" then
       -- Avoid running the 'main' set of tests twice
       exit(0)
     end
+  elseif options["target"] == "clean" then
+    local failure
+    for i = 1, #checkconfigs do
+      opts["config"] = {checkconfigs[i]}
+      failure = 0 ~= call({"."}, "clean", opts) or failure
+    end
+    exit(failure and 1 or 0)
   end
 end
 if #checkconfigs == 1 and


### PR DESCRIPTION
Suggested fix for #214: Make `l3build clean` operate like `l3build check` when it comes to multiple configurations.