### PR TITLE
stdmain: allow a target returning `nil`

### DIFF
--- a/l3build-stdmain.lua
+++ b/l3build-stdmain.lua
@@ -179,7 +179,7 @@ function main(target,names)
     errorlevel = target_list[target].func(names)
   end
   -- All done, finish up
-  if errorlevel ~= 0 then
+  if errorlevel or errorlevel ~= 0 then
     exit(1)
   else
     exit(0)


### PR DESCRIPTION
When [digging `pgf`'s CI](https://github.com/pgf-tikz/pgf/pull/1094#discussion_r766660074), I find currently, if a (user-declared) target returns `nil`, the `main()` in `stdmain` will call `exit(1)`. Since `nil` is the default return value of a Lua function, accepting it would be better.

This PR makes the `main()` call `exit(0)` when a target returns `nil`.

PS: Should I add a testfile?

```bash
$ cat build.lua
```
```lua
module = "l3buid-test"

target_list.myfun =
  {
    func = function() print("This is myfun2().") end
  }
```
```bash
# expected: "Exit code is 0"
# current: "Exit code is not 0"
$ l3build myfun && echo "Exit code is 0" || echo "Exit code is not 0"
This is myfun2().
Exit code is not 0
```