### PR TITLE
use form-string not form to guard against leading < or @

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Fixed
+- use `form-string` rather than `form` for all curl fields to avoid
+  misinterpreting leading `@` or `<` eg a description starting `<p>`
+
 ### Changed
 - Documentation of how to validate an upload
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ this project uses date-based 'snapshot' version identifiers.
 ### Fixed
 - use `form-string` rather than `form` for all curl fields to avoid
   misinterpreting leading `@` or `<` eg a description starting `<p>`
+  
+- Check the boolean value returned by executing shell commands in
+  l3build-upload and throw an error if this is false. This fixes
+  the issue that previously "validation successful" was reported
+  if curl failed.
 
 ### Changed
 - Documentation of how to validate an upload

--- a/l3build-upload.lua
+++ b/l3build-upload.lua
@@ -324,7 +324,7 @@ function ctan_single_field(fname,fvalue,max,desc,mandatory)
       vs = vs:gsub('`','\\`')
       vs = vs:gsub('\n','\\n')
 -- for strings on commandline version      ctan_post=ctan_post .. ' --form "' .. fname .. "=" .. vs .. '"'
-      ctan_post=ctan_post .. '\nform="' .. fname .. '=' .. vs .. '"'
+      ctan_post=ctan_post .. '\nform-string="' .. fname .. '=' .. vs .. '"'
     end
   else
     error("The value of the field '" .. fname .."' must be a scalar not a table")

--- a/l3build-upload.lua
+++ b/l3build-upload.lua
@@ -245,8 +245,12 @@ end
 function shell(s)
   local h = assert(popen(s, 'r'))
   local t = assert(h:read('*a'))
-  h:close()
-  return t
+  local success = h:close()
+  if (success) then
+   return t
+  else
+   error("\nError from shell command:\n" .. s .. "\n" .. t .. "\n")
+  end
 end
 
 function construct_ctan_post(uploadfile,debug)


### PR DESCRIPTION
the curl manual says

```
--form-string <name=string>

(HTTP SMTP IMAP) Similar to -F, --form except that the value string for the named parameter is used literally.
Leading '@' and '<' characters, and the ';type=' string in the value have no special meaning.
Use this in preference to -F, --form if there's any possibility that the string value may accidentally trigger
the '@' or '<' features of -F, --form. 
```

and eg the pgf description starts with `<p>` and the leading `<` breaks everything.

This uses `form-string` instead of `form` for all fields except the zip file upload that needs the leading `@` to be interpreted.