### PR TITLE
Fix normalization pattern for luaotfload font cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ this project uses date-based 'snapshot' version identifiers.
 
 ### Fixed
 - Use correct name for `options` table in multi configuration management code
+- Correctly normalize luaotfload font cache path
 
 ## [2021-12-09]
 

--- a/l3build-check.lua
+++ b/l3build-check.lua
@@ -147,7 +147,7 @@ local function normalize_log(content,engine,errlevels)
     -- Images
     line = gsub(line, "<" .. pattern .. ">", "<../%1>")
     -- luaotfload files start with keywords
-    line = gsub(line, "from " .. pattern .. "%(", "from. ./%1(")
+    line = gsub(line, "from " .. pattern .. "$", "from ../%1")
     line = gsub(line, ": " .. pattern .. "%)", ": ../%1)")
     -- Deal with XeTeX specials
     if match(line, "^%.+\\XeTeX.?.?.?file") then


### PR DESCRIPTION
`normalize_log` already normalizes paths which are preceded by `from ` and followed by `(` for luaotfload, but luaotfload does not actually write such paths in current versions. Instead normalize paths preseded by `from ` and followed by the end of the line in order to capture especially the path to the used font cache.