### PR TITLE
use pdfmeta command if available for compability with pdfmanagement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Changed
+ - if `\pdfmeta_set_regression_data:` is defined it is used
+   to set the meta data.
+   
 ## [2022-02-24]
 
 ### Fixed

--- a/l3build.dtx
+++ b/l3build.dtx
@@ -1545,7 +1545,7 @@
 % \meta{package}|-ctan.curlopt|. This is then passed to curl using its
 % |--config| commandline option.  (Using an intermediate file helps
 % keep \pkg{l3build} portable between systems using different
-% commandline quoting conventions. Any backslashes are doubled when writing 
+% commandline quoting conventions. Any backslashes are doubled when writing
 % to this file, so they do not need to be doubled in announcement and note texts.)
 %
 % By default the file is written into the current directory alongside
@@ -2497,48 +2497,53 @@
 % environment side (as not all output can be controlled here).
 % There is a limit to what can be done with the underlying PDF structure so
 % there is no point entirely suppressing \texttt{Producer}: simply avoid
-% any version numbers.
+% any version numbers. If the pdfmanagement is loaded we use its function
+% if it exists.
 %    \begin{macrocode}
-\ifnum 0%
-  \ifx\pdfoutput\@undefined\else\ifnum\pdfoutput>0 1\fi\fi
-  \ifx\outputmode\@undefined\else\ifnum\outputmode>0 1\fi\fi
-  >0 %
-  \ifx\pdfvariable\@undefined
-    \pdfinfo{/Producer (\ifx\directlua\@undefined pdf\else Lua\fi TeX)}
-    \ifx\pdfinfoomitdate\@undefined\else
-      \pdfinfoomitdate     = 1 %
-      \pdfsuppressptexinfo = \numexpr
+\ifcsname pdfmeta_set_regression_data:\endcsname
+   \csname pdfmeta_set_regression_data:\endcsname
+\else
+  \ifnum 0%
+    \ifx\pdfoutput\@undefined\else\ifnum\pdfoutput>0 1\fi\fi
+    \ifx\outputmode\@undefined\else\ifnum\outputmode>0 1\fi\fi
+    >0 %
+    \ifx\pdfvariable\@undefined
+      \pdfinfo{/Producer (\ifx\directlua\@undefined pdf\else Lua\fi TeX)}
+      \ifx\pdfinfoomitdate\@undefined\else
+        \pdfinfoomitdate     = 1 %
+        \pdfsuppressptexinfo = \numexpr
+              0
+            + 1 % PTEX.Fullbanner
+            + 2 % PTEX.FileName
+          \relax
+        \pdftrailerid{}
+      \fi
+    \else
+      \pdfextension info{/Producer (LuaTeX)}
+      \pdfvariable suppressoptionalinfo \numexpr
             0
-          + 1 % PTEX.Fullbanner
-          + 2 % PTEX.FileName
+          +   1 % PTEX.Fullbanner
+          +   2 % PTEX.FileName
+          +  32 % CreationDate
+          +  64 % ModDate
+          + 512 % ID
         \relax
-      \pdftrailerid{}
     \fi
   \else
-    \pdfextension info{/Producer (LuaTeX)}
-    \pdfvariable suppressoptionalinfo \numexpr
-          0
-        +   1 % PTEX.Fullbanner
-        +   2 % PTEX.FileName
-        +  32 % CreationDate
-        +  64 % ModDate
-        + 512 % ID
-      \relax
-  \fi
-\else
-  \ifx\XeTeXversion\@undefined
-    \special{! <</DocumentUUID (DocumentUUID)>> setpagedevice}
-    \special{! <</InstanceUUID (InstanceUUID)>> setpagedevice}
-  \else
-    \special{%
-      pdf: docinfo
-        <<
-          /Creator        (TeX)
-          /CreationDate   ()
-          /ModDate        ()
-          /Producer       (xdvipdfmx)
-        >>
-    }
+    \ifx\XeTeXversion\@undefined
+      \special{! <</DocumentUUID (DocumentUUID)>> setpagedevice}
+      \special{! <</InstanceUUID (InstanceUUID)>> setpagedevice}
+    \else
+      \special{%
+        pdf: docinfo
+          <<
+            /Creator        (TeX)
+            /CreationDate   ()
+            /ModDate        ()
+            /Producer       (xdvipdfmx)
+          >>
+      }
+    \fi
   \fi
 \fi
 %    \end{macrocode}


### PR DESCRIPTION
The current version of regression-test.tex uses primitive commands like \pdfinfo which shouldn't be used if the pdfmanagement is active. This pull requests uses instead `\pdfmeta_set_regression:` if it exists, a command I added to the pdfmanagement. 