### PR TITLE
Fix issue when installing into directory with spaces

### DIFF
--- a/l3build-file-functions.lua
+++ b/l3build-file-functions.lua
@@ -198,7 +198,7 @@ function escapepath(path)
   else
     path = gsub(path,"\\ ","[PATH-SPACE]")
     path = gsub(path," ","\\ ")
-    return gsub(path,"%[PATH-SPACE%]","\\ ")
+    return gsub(path,"%[PATH%-SPACE%]","\\ ")
   end
 end
 
@@ -234,13 +234,13 @@ function cp(glob, source, dest)
     if os_type == "windows" then
       if direxists(p.cwd) then
         errorlevel = execute(
-          'xcopy /y /e /i "' .. unix_to_win(p.cwd) .. '" "'
-             .. unix_to_win(dest .. '/' .. p.src) .. '" > nul'
+          'xcopy /y /e /i "' .. unix_to_win(p.cwd) .. '" '
+             .. unix_to_win(dest .. '/' .. escapepath(p.src)) .. ' > nul'
         ) and 0 or 1
       else
         errorlevel = execute(
-          'xcopy /y "' .. unix_to_win(p.cwd) .. '" "'
-             .. unix_to_win(dest .. '/') .. '" > nul'
+          'xcopy /y "' .. unix_to_win(p.cwd) .. '" '
+             .. unix_to_win(dest .. '/') .. ' > nul'
         ) and 0 or 1
       end
     else
@@ -250,7 +250,7 @@ function cp(glob, source, dest)
         if errorlevel ~=0 then return errorlevel end
       end
       errorlevel = execute(
-        "cp -RLf '" .. p.cwd .. "' '" .. dest .. "'"
+        "cp -RLf '" .. p.cwd .. "' " .. dest
       ) and 0 or 1
     end
     if errorlevel ~=0 then
@@ -367,6 +367,7 @@ function remove_duplicates(a)
 end
 
 function mkdir(dir)
+  dir = escapepath(dir)
   if os_type == "windows" then
     -- Windows (with the extensions) will automatically make directory trees
     -- but issues a warning if the dir already exists: avoid by including a test


### PR DESCRIPTION
Fix for #228.

There are three independent issues here:

  1. `mkdir` doesn't escape it's argument. Fixed by adding `escapepath`.
  2. `escapepath` is broken on non-Windows for pathes with spaces since the pattern doesn't take care of `-` being a special character. Fixed by adding a `%`.
  3. `cp` always gets an escaped path passed as destination but quotes the destination argument again. For now this PR removes the quoting, but in the longer term I think that this should be fixed the other way around.

Generally while this change allows for changes in tdshome, the handling of spaces in filenames needs much more fundamental work.