### PR TITLE
fix!: make sure that typesetsuppfiles are copied into the localdir

### DIFF
--- a/l3build-typesetting.lua
+++ b/l3build-typesetting.lua
@@ -185,7 +185,7 @@ local function docinit()
     cp(file, sourcefiledir, typesetdir)
   end
   for _,file in pairs(typesetsuppfiles) do
-    cp(file, supportdir, typesetdir)
+    cp(file, supportdir, localdir)
   end
   -- Main loop for doc creation
   local errorlevel = typeset_demo_tasks()


### PR DESCRIPTION
The [documentation][doc] says that `typesetsuppfiles` are copied into the `localdir`,
but in fact they are copied into the `typesetdir`. This PR fixes this problem.

[doc]: https://github.com/latex3/l3build/blob/87f00fcca1f8db39fefa1f482fb2f47f308db377/l3build.dtx#L513