### PR TITLE
Create directories before copying files into them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Fixed
+- Copying of nested directories
+
 ## [2022-04-19]
 
 ### Changed

--- a/l3build-install.lua
+++ b/l3build-install.lua
@@ -327,9 +327,17 @@ function install_files(target,full,dry_run)
 
   if errorlevel ~= 0 then return errorlevel end
 
+  -- Track created destination directories to avoid overhead from
+  -- repeatedly creating them
+  local destination_dirs = {}
+
   -- Files are all copied in one shot: this ensures that cleandir()
   -- can't be an issue even if there are complex set-ups
   for _,v in ipairs(installmap) do
+    if not destination_dirs[v.dest] then
+      mkdir(v.dest)
+      destination_dirs[v.dest] = true
+    end
     errorlevel = cp(v.file,v.source,v.dest)
     if errorlevel ~= 0  then return errorlevel end
   end


### PR DESCRIPTION
Solves an issue where copying files on Linux into subdirectories copied the files into the parent directory with the subdirectory name as filename.