### PR TITLE
typo

### DIFF
--- a/l3build.dtx
+++ b/l3build.dtx
@@ -1129,7 +1129,7 @@
 %       if run == 1 then
 %         return "biber " .. name
 %       else
-%         return 0
+%         return ""
 %       end
 %     end
 %   \end{lstlisting}


### PR DESCRIPTION
There is a typo in documention. `return 0` leads to this runtime error:

```
sh: 0: command not found
```