### PR TITLE
Use runcmd in dvitopdf to allow for local texmf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Fixed
+- Ensure `texmf.cnf` work correctly for `dvips`
+
 ## [2022-11-10]
 
 ### Changed

--- a/l3build-check.lua
+++ b/l3build-check.lua
@@ -778,8 +778,7 @@ function runtest(name, engine, hide, ext, test_type, breakout)
   rmfile(testdir,name .. logext)
   local errlevels = {}
   for i = 1, checkruns do
-    errlevels[i] = run(
-      testdir,
+    errlevels[i] = runcmd(
       -- No use of localdir here as the files get copied to testdir:
       -- avoids any paths in the logs
       os_setenv .. " TEXINPUTS=." .. localtexmf()
@@ -791,10 +790,6 @@ function runtest(name, engine, hide, ext, test_type, breakout)
       -- Avoid spurious output from (u)pTeX
       os_setenv .. " GUESS_INPUT_KANJI_ENCODING=0"
         .. os_concat ..
-      -- Allow for local texmf files
-      os_setenv .. " TEXMFCNF=." .. os_pathsep
-        .. os_concat ..
-      set_epoch_cmd(epoch, forcecheckepoch) ..
       -- Ensure lines are of a known length
       os_setenv .. " max_print_line=" .. maxprintline
         .. os_concat ..
@@ -803,7 +798,8 @@ function runtest(name, engine, hide, ext, test_type, breakout)
         .. setup(lvtfile)
         .. (hide and (" > " .. os_null) or "")
         .. os_concat ..
-      runtest_tasks(jobname(lvtfile),i)
+      runtest_tasks(jobname(lvtfile),i),
+      testdir
     )
     -- Break the loop if the result is stable
     if breakout and i < checkruns then

--- a/l3build-typesetting.lua
+++ b/l3build-typesetting.lua
@@ -35,17 +35,6 @@ local match = string.match
 
 local os_type = os.type
 
-function dvitopdf(name, dir, engine, hide)
-  runcmd(
-    "dvips " .. name .. dviext
-      .. (hide and (" > " .. os_null) or "")
-      .. os_concat ..
-    "ps2pdf " .. ps2pdfopt .. name .. psext
-      .. (hide and (" > " .. os_null) or ""),
-    dir
-  )
-end
-
 -- An auxiliary used to set up the environmental variables
 function runcmd(cmd,dir,vars)
   dir = dir or "."
@@ -64,6 +53,17 @@ function runcmd(cmd,dir,vars)
     env = env .. os_concat .. os_setenv .. " " .. var .. "=" .. envpaths
   end
   return run(dir,set_epoch_cmd(epoch, forcedocepoch) .. env .. os_concat .. cmd)
+end
+
+function dvitopdf(name, dir, engine, hide)
+  runcmd(
+    "dvips " .. name .. dviext
+      .. (hide and (" > " .. os_null) or "")
+      .. os_concat ..
+    "ps2pdf " .. ps2pdfopt .. name .. psext
+      .. (hide and (" > " .. os_null) or ""),
+    dir
+  )
 end
 
 function biber(name,dir)

--- a/l3build-typesetting.lua
+++ b/l3build-typesetting.lua
@@ -36,14 +36,13 @@ local match = string.match
 local os_type = os.type
 
 function dvitopdf(name, dir, engine, hide)
-  run(
-    dir,
-    set_epoch_cmd(epoch, forcecheckepoch) ..
+  runcmd(
     "dvips " .. name .. dviext
       .. (hide and (" > " .. os_null) or "")
       .. os_concat ..
     "ps2pdf " .. ps2pdfopt .. name .. psext
-      .. (hide and (" > " .. os_null) or "")
+      .. (hide and (" > " .. os_null) or ""),
+    dir
   )
 end
 


### PR DESCRIPTION
The current implementation of `dvitopdf` does not set `TEXMFCNF`, which prevents `dvips` from finding local texmf fonts. The PR fixes this problem by invoking `dvips` via `runcmd` function.