### PR TITLE
Update PDF-based test

### DIFF
--- a/testfiles-pdf/00-test-2.tpf
+++ b/testfiles-pdf/00-test-2.tpf
@@ -6,7 +6,7 @@
 >>
 stream
 BT
-/F29 9.9626 Tf 87.691 759.927 Td [(#$%&)]TJ -5.23 -11.955 Td [(#$%&)]TJ
+/F33 9.9626 Tf 87.691 759.927 Td [(#$%&)]TJ -5.23 -11.955 Td [(#$%&)]TJ
 ET
 endstream
 endobj
@@ -21,7 +21,7 @@ endobj
 endobj
 1 0 obj
 <<
-/Font << /F29 4 0 R >>
+/Font << /F33 4 0 R >>
 /ProcSet [ /PDF /Text ]
 >>
 endobj


### PR DESCRIPTION
to fix the workflow failure, see https://github.com/latex3/l3build/actions/runs/3895731432/jobs/6651406511.

f6814cb (Update PDF-based test, 2022-01-28) gives some explanation about why the `/Fxx` changes.