### PR TITLE
Fix #261, add zsh completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Added
+- Completion support for `zsh`
+
 ## [2023-02-16]
 
 ### Changed

--- a/l3build-arguments.lua
+++ b/l3build-arguments.lua
@@ -40,7 +40,8 @@ option_list =
       {
         desc  = "Sets the config(s) used for running tests",
         short = "c",
-        type  = "table"
+        type  = "table",
+        complete = "lua_file"
       },
     date =
       {
@@ -71,7 +72,8 @@ option_list =
       {
         desc  = "Sets the engine(s) to use for running test",
         short = "e",
-        type  = "table"
+        type  = "table",
+        complete = "engine"
       },
     epoch =
       {
@@ -82,7 +84,8 @@ option_list =
       {
         desc  = "Take the upload announcement from the given file",
         short = "F",
-        type  = "string"
+        type  = "string",
+        complete = "file"
       },
     first =
       {
@@ -110,7 +113,8 @@ option_list =
       {
         desc  = "Print this message and exit",
         short = "h",
-        type  = "boolean"
+        type  = "boolean",
+        stop_completions = {"option", "target", "name"}
       },
     last =
       {
@@ -158,7 +162,8 @@ option_list =
     version =
       {
         desc = "Print version information and exit",
-        type = "boolean"
+        type = "boolean",
+        stop_completions = {"option", "target", "name"}
       }
   }
 

--- a/l3build-complete.lua
+++ b/l3build-complete.lua
@@ -1,0 +1,148 @@
+--[[
+
+File l3build-complete.lua Copyright (C) 2018,2020,2021 The LaTeX Project
+
+It may be distributed and/or modified under the conditions of the
+LaTeX Project Public License (LPPL), either version 1.3c of this
+license or (at your option) any later version.  The latest version
+of this license is in the file
+
+   http://www.latex-project.org/lppl.txt
+
+This file is part of the "l3build bundle" (The Work in LPPL)
+and all files in that bundle must be distributed together.
+
+-----------------------------------------------------------------------
+
+The development version of the bundle can be found at
+
+   https://github.com/latex3/l3build
+
+for those people who are interested.
+
+--]]
+
+local insert = table.insert
+local match  = string.match
+local gsub   = string.gsub
+local sort   = table.sort
+local concat = table.concat
+
+function complete(name)
+  if name == "zsh" then
+    complete_zsh()
+  end
+end
+
+function complete_zsh()
+  local zsh_template = [=[
+#compdef {{ scriptname }}
+
+__l3build() {
+  local targets=(
+    {{ targets }}
+  )
+  local options=(
+    {{ options }}
+  )
+  _arguments -s -S $options \
+    "1:target:(($targets))" \
+    "*::name:->name"
+  case $state in
+    name)
+      case $words[1] in
+        complete)
+          _arguments '1:shell:(zsh)'
+        ;;
+      esac
+    ;;
+  esac
+}
+
+if [[ $zsh_eval_context[-1] == loadautofunc ]]; then
+  # autoload from fpath, call function directly
+  __l3build "$@"
+else
+  # eval/source/. command, register function for later
+  compdef __l3build {{ scriptname }}
+fi
+]=]
+  local function setup_list(list)
+    local longest = 0
+    for k,_ in pairs(list) do
+      if k:len() > longest then
+        longest = k:len()
+      end
+    end
+    -- Sort the options
+    local t = { }
+    for k,_ in pairs(list) do
+      insert(t, k)
+    end
+    sort(t)
+    return longest,t
+  end
+
+  local scriptname = "l3build"
+  if not (match(arg[0], "l3build%.lua$") or match(arg[0],"l3build$")) then
+    scriptname = arg[0]
+  end
+  local targets = {}
+  local _,t = setup_list(target_list)
+  for _,k in ipairs(t) do
+    local target = target_list[k]
+    if target["desc"] then
+      insert(targets, "'" .. k .. ":" .. gsub(
+        target["desc"], "[: ]", "\\%0"
+      ) .. "'")
+    end
+  end
+  local options = {}
+  _,t = setup_list(option_list)
+  local stop_completion_map = {option = "-", target = ":", name = "*"}
+  for _,k in ipairs(t) do
+    local opt = option_list[k]
+    if opt["desc"] then
+      local desc = "'[" .. gsub(
+        gsub(
+          opt["desc"], "'", "'\\''"
+        ), "[:%[%]]", "\\%0"
+      ) .. "]'"
+      local prefix = ""
+      if opt["stop_completions"] then
+        local stop_completions = {}
+        for _, stop_completion in ipairs(opt["stop_completions"]) do
+          insert(stop_completions, stop_completion_map[stop_completion])
+        end
+        prefix = "'(" .. concat(stop_completions, " ") .. ")'"
+      end
+      local option = "--" .. k
+      if opt["short"] then
+        option = "{--" .. k .. ",-" .. opt["short"] .. "}"
+      end
+      local suffix = ":"
+      if opt["type"] == "boolean" then
+        suffix = ""
+      end
+      if opt["complete"] then
+        suffix = suffix .. opt["complete"] .. ":"
+      end
+      if opt["complete"] == "lua_file" then
+        suffix = suffix .. "'_files -g \"*.lua\"'"
+      elseif opt["complete"] == "file" then
+        suffix = suffix .. "_files"
+      elseif opt["complete"] == "engine" then
+        suffix = suffix .. "'(pdftex xetex luatex ptex uptex)'"
+      end
+      insert(options, prefix .. option .. desc .. suffix)
+    end
+  end
+  local output = gsub(
+    gsub(
+      gsub(
+        zsh_template, "{{ targets }}", concat(targets, "\n    ")
+      ), "{{ options }}", concat(options, "\n    ")
+    ), "{{ scriptname }}", scriptname
+  )
+  print(output)
+end

--- a/l3build-stdmain.lua
+++ b/l3build-stdmain.lua
@@ -70,6 +70,10 @@ target_list =
         pre  = function() return(dep_install(unpackdeps)) end
       },
     -- Public targets
+    complete =
+      {
+        desc = "Print shell completion script",
+      },
     check =
       {
         bundle_target = true,

--- a/l3build.1
+++ b/l3build.1
@@ -15,6 +15,8 @@ The most commonly used l3build commands are:
 Run all automated tests
 .IP clean
 Clean out directory tree
+.IP complete
+Print shell completion script
 .IP doc
 Typesets all documentation files
 .IP install

--- a/l3build.dtx
+++ b/l3build.dtx
@@ -338,6 +338,7 @@
 % \item check
 % \item check \meta{name(s)}
 % \item clean
+% \item complete \meta{shell name}
 % \item ctan
 % \item doc
 % \item doc \meta{name(s)}
@@ -442,6 +443,33 @@
 % This command removes all temporary files used for package bundling and regression testing.
 % In the standard layout, these are all files within the directories defined by \var{localdir}, \var{testdir}, \var{typesetdir} and \var{unpackdir}, as well as all files defined in the \var{cleanfiles} variable in the same directory as the script.
 % The defaults are |.pdf| files from typesetting (|doc|) and |.zip| files from bundling (|ctan|).
+% \end{buildcmd}
+%
+% \begin{buildcmd}{complete \meta{shell name}}
+% This command print shell completion script. Now it only supports zsh. (A pull request is welcome!)
+%
+% Zsh users must \verb|autoload -Uz compinit && compinit| in \verb|~/.zshrc| to enable completion. Then users have two methods to install completion scripts:
+%
+% \begin{itemize}
+%   \item Users can add \verb|eval "$(l3build completion zsh)"| to \verb|~/.zshrc|.
+%   \item Users can add the following file (also provided by \href{https://github.com/zsh-users/zsh-completions}{zsh-completions}) to \\\verb|/usr/share/zsh/site-functions/_l3build|:
+% \begin{verbatim}
+% #compdef l3build
+% (( $+functions[__l3build] )) || eval "$(l3build complete zsh)" && __l3build
+% \end{verbatim}
+%     Then \verb|grep l3build ~/.zcompdump| to confirm:
+% \begin{verbatim}
+% 'l3build' '_l3build'
+% \end{verbatim}
+% If not, \verb|rm ~/.zcompdump|, then \verb|compinit| again.
+%
+% Note: \verb|/usr/share| is only for GNU/Linux, for other OSs, try:
+% \begin{description}
+%   \item[macOS (homebrew, x86)]\verb|/usr/local/share|
+%   \item[macOS (homebrew, arm)]\verb|/opt/homebrew/share|
+%   \item[Android (Termux)]\verb|/data/data/com.termux/files/usr/share|
+%   \item[Windows (Msys2 Mingw64)]\verb|/mingw64/share|
+% \end{description}
 % \end{buildcmd}
 %
 %

--- a/l3build.lua
+++ b/l3build.lua
@@ -56,6 +56,7 @@ end
 -- Minimal code to do basic checks
 build_require("arguments")
 build_require("help")
+build_require("complete")
 
 build_require("file-functions")
 build_require("typesetting")
@@ -70,6 +71,13 @@ build_require("manifest-setup")
 build_require("tagging")
 build_require("upload")
 build_require("stdmain")
+
+if options["target"] == "complete" then
+  for _, v in pairs(options["names"]) do
+    complete(v)
+  end
+  exit(0)
+end
 
 -- This has to come after stdmain(),
 -- and that has to come after the functions are defined


### PR DESCRIPTION
Users must `autoload -Uz compinit && compinit` in `~/.zshrc` to enable
completion. Then

1. Users can add `eval "$(l3build completion zsh)"` to `~/.zshrc`
2. Users can add the following file (will be added to
<https://github.com/zsh-users/zsh-completions>) to `/usr/share/zsh/site-functions/_l3build`:

```zsh

(( $+functions[__l3build] )) || eval "$(l3build complete zsh)" && __l3build
```

Then `grep l3build ~/.zcompdump` to confirm:

```
'l3build' '_l3build'
```

If not, `rm ~/.zcompdump`, then `compinit` again.

Note: `/usr/share` is only for linux, for other OSs, try

- macOS: `/usr/local/share`
- Android (Termux): `/data/data/com.termux/files/usr/share`
- Windows (msys2/mingw64): `/mingw64/share`
