### PR TITLE
Ensure `testdir` and `resultdir` exist even with `--dirty`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Fixed
+- Ensure directories `testdir` and `resultdir` exist when `--dirty` is set
+
 ## [2023-02-16]
 
 ### Changed

--- a/l3build-check.lua
+++ b/l3build-check.lua
@@ -55,7 +55,10 @@ local remove           = os.remove
 -- Set up the check system files: needed for checking one or more tests and
 -- for saving the test files
 function checkinit()
-  if not options["dirty"] then
+  if options["dirty"] then
+    mkdir(testdir)
+    mkdir(resultdir)
+  else
     cleandir(testdir)
     cleandir(resultdir)
   end


### PR DESCRIPTION
Currently, if one run `l3build check --dirty <name>` in a clean repo, `testdir` is created as a file which causes problems.

To reproduce using `l3build` repo itself:
```bash
$ git clone --depth=1 git@github.com:latex3/l3build.git
$ cd l3build
$ l3build check --dirty 00-test-1
```
Then you'll end with
```
Transcript written on l3build.log.
sh: ./build/test/ascii.tcx: Not a directory
Running checks on
  00-test-1 (1/1)
./l3build-file-functions.lua:182: Unable to change working directory to './build/test'
Not a directory
```

This PR fixes this problem. Now `testdir` and `resultdir` always exist, with or without `--dirty`.