### PR TITLE
Unify `testdir` when config is passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Changed
+- Unify `testdir` by dropping possibly trailing `.lua` passed to `--config`
+
 ### Fixed
 - Ensure directories `testdir` and `resultdir` exist when `--dirty` is set
 

--- a/l3build.lua
+++ b/l3build.lua
@@ -205,23 +205,23 @@ if #checkconfigs > 1 then
   end
 end
 if #checkconfigs == 1 and
-   checkconfigs[1] ~= "build" and
-   (options["target"] == "check" or options["target"] == "save" or options["target"] == "clean") then
-   local configname  = gsub(checkconfigs[1], "%.lua$", "")
-   local config = "./" .. configname .. ".lua"
-   if fileexists(config) then
-     local savedtestfiledir = testfiledir
-     dofile(config)
-     testdir = testdir .. "-" .. configname
-     -- Reset testsuppdir if required
-     if savedtestfiledir ~= testfiledir and
-       testsuppdir == savedtestfiledir .. "/support" then
-       testsuppdir = testfiledir .. "/support"
-     end
-   else
-     print("Error: Cannot find configuration " ..  checkconfigs[1])
-     exit(1)
-   end
+  checkconfigs[1] ~= "build" and
+  (options["target"] == "check" or options["target"] == "save" or options["target"] == "clean") then
+  local configname  = gsub(checkconfigs[1], "%.lua$", "")
+  local config = "./" .. configname .. ".lua"
+  if fileexists(config) then
+    local savedtestfiledir = testfiledir
+    dofile(config)
+    testdir = testdir .. "-" .. configname
+    -- Reset testsuppdir if required
+    if savedtestfiledir ~= testfiledir and
+      testsuppdir == savedtestfiledir .. "/support" then
+      testsuppdir = testfiledir .. "/support"
+    end
+  else
+    print("Error: Cannot find configuration " ..  checkconfigs[1])
+    exit(1)
+  end
 end
 
 -- Call the main function

--- a/l3build.lua
+++ b/l3build.lua
@@ -207,11 +207,12 @@ end
 if #checkconfigs == 1 and
    checkconfigs[1] ~= "build" and
    (options["target"] == "check" or options["target"] == "save" or options["target"] == "clean") then
-   local config = "./" .. gsub(checkconfigs[1],"%.lua$","") .. ".lua"
+   local configname  = gsub(checkconfigs[1], "%.lua$", "")
+   local config = "./" .. configname .. ".lua"
    if fileexists(config) then
      local savedtestfiledir = testfiledir
      dofile(config)
-     testdir = testdir .. "-" .. checkconfigs[1]
+     testdir = testdir .. "-" .. configname
      -- Reset testsuppdir if required
      if savedtestfiledir ~= testfiledir and
        testsuppdir == savedtestfiledir .. "/support" then


### PR DESCRIPTION
Using `l3build` repo as an example, currently, 
- `l3build check -c config-pdf` creates `./build/config-pdf` as `testdir`, while
- `l3build check -c config-pdf.lua` creates `./build/config-pdf.lua` as `testdir`, noted the trailing `.lua` in directory name.

Since the usage `-c config-xxx.lua` is supported and may be naturally used (by human) with the help of shell completion (type `-c config-` followed by a Tab), this PR unifies the name pattern of `testdir`. Now in both cases `testdir` without trailing `.lua` will be created.

------

Tip: To review changes, you may want to check "Hide whitespace" and reload
![image](https://user-images.githubusercontent.com/6376638/219940946-fe771d5f-7afd-4312-bcfa-a635cb442ad5.png)