### PR TITLE
fix epoch setting with xetex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ this project uses date-based 'snapshot' version identifiers.
 
 ### Fixed
 - Ensure directories `testdir` and `resultdir` exist when `--dirty` is set
+- epoch settings with xetex
 
 ## [2023-02-16]
 

--- a/l3build-check.lua
+++ b/l3build-check.lua
@@ -790,6 +790,8 @@ function runtest(name, engine, hide, ext, test_type, breakout)
       os_setenv .. " LUAINPUTS=." .. localtexmf()
         .. (checksearch and os_pathsep or "")
         .. os_concat ..
+      -- ensure epoch settings
+        set_epoch_cmd(epoch, forcecheckepoch) ..  
       -- Ensure lines are of a known length
       os_setenv .. " max_print_line=" .. maxprintline
         .. os_concat ..


### PR DESCRIPTION
That got inadvertendly lost in a previous commit.