### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,29 +13,10 @@ jobs:
       # Boilerplate
       - name: Checkout repository
         uses: actions/checkout@v3
-      # GitHub Actions don't regenerate the test if the key doesn't change, so
-      # we integrate a random UUID into the key to keep them different.
-      # DO NOT CHANGE THIS
-      - name: Generate unique ID
-        id: get-id
-        run: |
-          echo "id=$(cat /proc/sys/kernel/random/uuid)" >> $GITHUB_STATE
-      # Actually load the cache. Since we never reuse the key, we need restore-keys
-      # to indicate the prefix of our caches. This loads the newest cache with this
-      # prefix in the key.
-      #
-      # If we want to force regeneration of the cache, increase the number after
-      # *both* instances of "texlive-v"
-      - name: Load cache
-        uses: actions/cache@v3
-        with:
-          path: ~/texlive
-          key: texlive-v0-${{ steps.get-id.outputs.id }}
-          restore-keys: texlive-v0-
       # We need Ghostscript for XeTeX tests.
       - run: sudo apt-get install ghostscript
       - name: Install TeX Live
-        uses: zauguin/install-texlive@v1
+        uses: zauguin/install-texlive@v2
         with:
           # List the required TeX Live packages in a separate file to allow reuse in
           # different workflows.

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       # Boilerplate
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       # GitHub Actions don't regenerate the test if the key doesn't change, so
       # we integrate a random UUID into the key to keep them different.
       # DO NOT CHANGE THIS


### PR DESCRIPTION
- Update gh action `actions/checkout` to v3, to use node 16 hence eliminate "Node.js 12 actions are deprecated" warning.
  See for example https://github.com/latex3/l3build/actions/runs/4220820389
- Update gh action `zauguin/install-texlive` to v2, which has caching integrated. Drop no longer needed caching steps.
  See https://github.com/zauguin/install-texlive/compare/v1.2.1...v2.0.0