### PR TITLE
Fix epoch setting with `dvitopdf()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Fixed
+- Restore epoch settings for `dvitopdf()`
+
 ## [2023-02-20]
 
 ### Changed

--- a/l3build-check.lua
+++ b/l3build-check.lua
@@ -791,7 +791,7 @@ function runtest(name, engine, hide, ext, test_type, breakout)
         .. (checksearch and os_pathsep or "")
         .. os_concat ..
       -- ensure epoch settings
-        set_epoch_cmd(epoch, forcecheckepoch) ..  
+      set_epoch_cmd(epoch, forcecheckepoch) ..
       -- Ensure lines are of a known length
       os_setenv .. " max_print_line=" .. maxprintline
         .. os_concat ..

--- a/l3build-typesetting.lua
+++ b/l3build-typesetting.lua
@@ -57,6 +57,7 @@ end
 
 function dvitopdf(name, dir, engine, hide)
   runcmd(
+    set_epoch_cmd(epoch, forcecheckepoch) ..
     "dvips " .. name .. dviext
       .. (hide and (" > " .. os_null) or "")
       .. os_concat ..


### PR DESCRIPTION
#262 mistakenly deleted two uses of `set_epoch_cmd(epoch, forcecheckepoch)`. #270 restored one in `runtest()`, and this PR restores another one in `dvitopdf()`.

I haven't found a way to test against this change, because Ghostscript (`ps2pdf`) doesn't respect epoch environment variables, and there seems to be no easy workaround. See a rejected request to Ghostscript https://bugs.ghostscript.com/show_bug.cgi?id=696765#c28. (Maybe `l3build` wants to normalize pdf further and I will open a new issue for this.)

------

@teatimeguest I guess the reason why two `set_epoch_cmd(epoch, forcecheckepoch)` were deleted is, with [`runcmd()`](https://github.com/latex3/l3build/blob/e5a68dabba9c5537d6571d10ee1b455071a693df/l3build-typesetting.lua#L39-L56) defined as
```lua
function runcmd(cmd, dir, vars)
  ...
  return run(dir, set_epoch_cmd(epoch, forcedocepoch) .. env .. os_concat .. cmd)
end
```
- `runcmd(cmd, dir)` and
- `run(dir, set_epoch_cmd(epoch, forcecheckpoch) .. cmd)`

were considered the same. They're not.
 - in `runcmd()`, it's `set_epoch_cmd(epoch, forcecheckepoch)`, `force_check_epoch`
 - in `runtest()` and `dvitopdf()`, it was `set_epoch_cmd(epoch, forcedocepoch)`, `force_doc_epoth`