### PR TITLE
Fully drop `stdconfig`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ this project uses date-based 'snapshot' version identifiers.
 - Restore epoch settings for `dvitopdf()`
 - Use plural form of variable `ps2pdfopts` consistently in code and doc, and 
   retain compatibility with singular form `ps2pdfopt` (issue #275)
+- Remove the last trace of dropped variable `stdconfig`
 
 ## [2023-02-20]
 

--- a/l3build.lua
+++ b/l3build.lua
@@ -126,9 +126,9 @@ check_engines()
 --
 
 -- When we have specific files to deal with, only use explicit configs
--- (or just the std one)
+-- (or just the default one)
 if options["names"] then
-  checkconfigs = options["config"] or {stdconfig}
+  checkconfigs = options["config"] or {"build"}
 else
   checkconfigs = options["config"] or checkconfigs
 end


### PR DESCRIPTION
The variable `stdconfig` was introduced in
- 9da3ee2 (Have stdconfig in checkconfigs table as-standard, 2017-12-07)
- 0004839 (Handle named tests with multiple configs (see #<span></span>15), 2018-02-21)

and then dropped in
- 9e6709d (Drop stdconfig as "build.lua" is now fixed, 2018-03-06)