### PR TITLE
Run engine sanity check per config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Changed
+- Run engine sanity check per config
+
 ### Fixed
 - Restore epoch settings for `dvitopdf()`
 - Use plural form of variable `ps2pdfopts` consistently in code and doc, and 

--- a/l3build-arguments.lua
+++ b/l3build-arguments.lua
@@ -291,16 +291,16 @@ end
 options = argparse()
 
 -- Sanity check
-function check_engines()
+function check_engines(config)
   if options["engine"] and not options["force"] then
-     -- Make a lookup table
-     local t = { }
+    -- Make a lookup table
+    local t = { }
     for _, engine in pairs(checkengines) do
       t[engine] = true
     end
     for _, engine in pairs(options["engine"]) do
       if not t[engine] then
-        print("\n! Error: Engine \"" .. engine .. "\" not set up for testing!")
+        print("\n! Error: Engine \"" .. engine .. "\" not set up for testing with configuration " .. config .. "!")
         print("\n  Valid values are:")
         for _, engine in ipairs(checkengines) do
           print("  - " .. engine)

--- a/l3build.lua
+++ b/l3build.lua
@@ -118,9 +118,6 @@ if options["epoch"] then
 end
 epoch = normalise_epoch(epoch)
 
--- Sanity check
-check_engines()
-
 --
 -- Deal with multiple configs for tests
 --
@@ -205,22 +202,28 @@ if #checkconfigs > 1 then
   end
 end
 if #checkconfigs == 1 and
-  checkconfigs[1] ~= "build" and
   (options["target"] == "check" or options["target"] == "save" or options["target"] == "clean") then
-  local configname  = gsub(checkconfigs[1], "%.lua$", "")
-  local config = "./" .. configname .. ".lua"
-  if fileexists(config) then
-    local savedtestfiledir = testfiledir
-    dofile(config)
-    testdir = testdir .. "-" .. configname
-    -- Reset testsuppdir if required
-    if savedtestfiledir ~= testfiledir and
-      testsuppdir == savedtestfiledir .. "/support" then
-      testsuppdir = testfiledir .. "/support"
-    end
+  if checkconfigs[1] == "build" then
+    -- Sanity check for default config
+    check_engines("build.lua")
   else
-    print("Error: Cannot find configuration " ..  checkconfigs[1])
-    exit(1)
+    local configname  = gsub(checkconfigs[1], "%.lua$", "")
+    local config = "./" .. configname .. ".lua"
+    if fileexists(config) then
+      local savedtestfiledir = testfiledir
+      dofile(config)
+      -- Sanity check for non-default config
+      check_engines(configname .. ".lua")
+      testdir = testdir .. "-" .. configname
+      -- Reset testsuppdir if required
+      if savedtestfiledir ~= testfiledir and
+        testsuppdir == savedtestfiledir .. "/support" then
+        testsuppdir = testfiledir .. "/support"
+      end
+    else
+      print("Error: Cannot find configuration " ..  configname .. ".lua")
+      exit(1)
+    end
   end
 end
 


### PR DESCRIPTION
If a sub-config file need to check some engine that's not checked by `build.lua`, currently running
```
l3build check -c <sub-config> -e <engine-not-checked-by-build>
```
ends with error `! Error: Engine "xxx" not set up for testing!`

Steps to reproduce it using `l3build` repo:
```bash
# clone l3build, tag 2023-02-20
$ git clone --depth 1 --branch 2023-02-20 git@github.com:latex3/l3build.git
$ cd l3build
# make "xetex" the engine that's checked by config-pdf.lua but not by build.lua
$ sed -i '' 's/"xetex", //g' build.lua

$ texlua l3build.lua check -c config-pdf -e xetex

! Error: Engine "xetex" not set up for testing!

  Valid values are:
  - pdftex
  - luatex
  - ptex
  - uptex
```

This PR makes the engine sanity check run for each config. The name of config file is also added to the corresponding error message.

Some tests,
```bash
# preperation
$ sed -i '' 's/"xetex", //g' build.lua

# succeed
$ texlua l3build.lua check -c config-pdf -e xetex
# fail, "xetex not set up for build.lua"
$ texlua l3build.lua check -c build -e xetex
# succeed for config-pdf.lua, fail for build.lua
$ texlua l3build.lua check -c config-pdf,build -e xetex
# fail for build.lua, succeed for config-pdf.lua
$ texlua l3build.lua check -c build,config-pdf -e xetex
# fail for build.lua, succeed for config-pdf.lua, fail for config-plain.lua
$ texlua l3build.lua check -e xetex
```

I think it's half bug half non-bug, and just to avoid merge conflicts the classification "Changed" is chosen. No strong opinion is held and I'm willing to do the re-classification if needed.

About testing l3build itself: I recalled there was an issue discussing this before, but can't find it right now.  Recently I saw [texdoc uses RSpec + Aruba](https://github.com/TeX-Live/texdoc/tree/master/spec) for testing itself.