### PR TITLE
Generalize normalization of ghostscript version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Changed
+- Generalize normalization of ghostscript version in PDF-based tests
+
 ## [2023-02-26]
 
 ### Changed

--- a/l3build-check.lua
+++ b/l3build-check.lua
@@ -556,7 +556,7 @@ local function normalize_pdf(content)
       not match(line,"^%%%%%+") then
       line = gsub(line,"%/ID( ?)%[<[^>]+><[^>]+>]","/ID%1[<ID-STRING><ID-STRING>]")
       line = gsub(line,"%/ID( ?)%[(%b())%2%]","/ID%1[<ID-STRING><ID-STRING>]")
-      line = gsub(line,"GhostScript %d%.%d+%.?%d*","GhostScript ...")
+      line = gsub(line,"Ghost[sS]cript %d+%.%d+%.?%d*","Ghostscript ...")
       new_content = new_content .. line .. os_newline
     end
   end


### PR DESCRIPTION
- match two-digit gs major version, like 10.00.0
- match both "GhostScript" and "Ghostscript" (it seems lowercased one is used in recent gs releases)

The normalization of ghostscript version in PDF-based tests is introduced in
- commit 81859b9 (Normalise GhostScript version in PDF tests, 2022-04-14) and
- commit 563db82 (Mumble, 2022-04-14)