### PR TITLE
Ensure `ps2pdfopts` is followed by a space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ this project uses date-based 'snapshot' version identifiers.
 - Generalize normalization of ghostscript version in PDF-based tests
 - Include UNIX timestamps in generated ZIP files
 
+### Fixed
+- Ensure when used, value of `ps2pdfopts` is surrounded by a space on both sides
+
 ## [2023-02-26]
 
 ### Changed

--- a/l3build-typesetting.lua
+++ b/l3build-typesetting.lua
@@ -61,7 +61,7 @@ function dvitopdf(name, dir, engine, hide)
     "dvips " .. name .. dviext
       .. (hide and (" > " .. os_null) or "")
       .. os_concat ..
-    "ps2pdf " .. ps2pdfopts .. name .. psext
+    "ps2pdf " .. ps2pdfopts .. " " .. name .. psext
       .. (hide and (" > " .. os_null) or ""),
     dir
   )


### PR DESCRIPTION
A tiny improvement found when playing with `ps2pdfopts`.  I still need some more experiments to turn #278 to non-draft so just in case I forgot this tiny stuff (I open this PR)...

Currently one has to set `ps2pdfopts = "-dNOSAFER␣"` then experienced user will set `ps2pdfopts = "␣-dNOSAFER␣"`, see for example [here](https://github.com/latex3/pdfresources/blob/97105e2b5c3e0b88d8b57c7a5149fe5440efc8e0/config-dvips.lua). This drawback was introduced in commit b27c8c2 (New "ps2pdfopts" variable, 2020-03-11).