### PR TITLE
Locate `.tlg` file using its base name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Fixed
+- All LuaTeX `.tlg` files were wrongly considered not engine-specific.
+  Introduced in #292 which tried to fix #291.
+
 ## [2023-03-22]
 
 ### Changed

--- a/l3build-check.lua
+++ b/l3build-check.lua
@@ -699,7 +699,7 @@ function compare_tlg(difffile, tlgfile, logfile, cleanup, name, engine)
   -- engine-specific .tlg file and the default engine is not LuaTeX
   local has_engine_specific_tlg =
       match(tlgfile, "%." .. engine .. "%" .. tlgext)
-      and locate({ testfiledir, unpackdir }, { tlgfile })
+      and locate({ testfiledir, unpackdir }, { basename(tlgfile) })
   if (match(engine,"^lua") or match(engine,"^harf"))
     and not has_engine_specific_tlg
     and not match(stdengine,"^lua")


### PR DESCRIPTION
Fix a regression introduced in #292. When locating a `.tlg` file, a path relative to `testdir` was used for, not its base name.

For example, if `tlgfile` equals `"./build/check/backend.luatex.tlg"` rathe than `backend.luatex.tlg`, then `locate({ testfiledir, unpackdir }, { tlgfile })` always return nil (`tlgfile` is not found in both directories).