### PR TITLE
Improve stdout, always quote module and config names

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -35,7 +35,7 @@ jobs:
           key: texlive-v0-${{ steps.get-id.outputs.id }}
           restore-keys: texlive-v0-
       # We need Ghostscript for XeTeX tests.
-      - run: sudo apt-get install ghostscript
+      - run: sudo apt-get update && sudo apt-get install ghostscript
       - name: Install TeX Live
         uses: zauguin/install-texlive@v1
         with:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       # We need Ghostscript for XeTeX tests.
-      - run: sudo apt-get install ghostscript
+      - run: sudo apt-get update && sudo apt-get install ghostscript
       - name: Install TeX Live
         uses: zauguin/install-texlive@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ this project uses date-based 'snapshot' version identifiers.
 
 ### Changed
 - Improve stdout "Running l3build with target ..."
+- Quote configuration name used in stdout
 
 ## [2023-03-27]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Changed
+- Improve stdout "Running l3build with target ..."
+
 ## [2023-03-27]
 
 ### Fixed

--- a/l3build-arguments.lua
+++ b/l3build-arguments.lua
@@ -300,7 +300,7 @@ function check_engines(config)
     end
     for _, engine in pairs(options["engine"]) do
       if not t[engine] then
-        print("\n! Error: Engine \"" .. engine .. "\" not set up for testing with configuration " .. config .. "!")
+        print("\n! Error: Engine \"" .. engine .. "\" not set up for testing with configuration \"" .. config .. "\"!")
         print("\n  Valid values are:")
         for _, engine in ipairs(checkengines) do
           print("  - " .. engine)

--- a/l3build-aux.lua
+++ b/l3build-aux.lua
@@ -133,9 +133,9 @@ function call(modules, target, opts)
   for _, module in ipairs(modules) do
     local text
     if module == "." and opts["config"] and #opts["config"]>0 then
-      text = " with configuration " .. opts["config"][1]
+      text = " and configuration \"" .. opts["config"][1] .. "\""
     else
-      text = " for module " .. module
+      text = " for module \"" .. module .. "\""
     end
     print("Running l3build with target \"" .. target .. "\"" .. text )
     local error_level = run(

--- a/l3build.lua
+++ b/l3build.lua
@@ -147,7 +147,7 @@ if #checkconfigs > 1 then
     end
     if next(failed) then
       for _,config in ipairs(failed) do
-        print("Failed tests for configuration " .. config .. ":")
+        print("Failed tests for configuration \"" .. config .. "\":")
         print("\n  Check failed with difference files")
         local testdir = testdir
         if config ~= "build" then
@@ -167,8 +167,8 @@ if #checkconfigs > 1 then
           end
           local f = open(testdir .. "/.savecommands")
           if not f then
-            print("Error: Cannot find save commands for configuration " ..
-              config)
+            print("Error: Cannot find save commands for configuration \"" ..
+              config .. "\"")
             exit(2)
           end
           for line in f:lines() do
@@ -221,7 +221,7 @@ if #checkconfigs == 1 and
         testsuppdir = testfiledir .. "/support"
       end
     else
-      print("Error: Cannot find configuration " ..  configname .. ".lua")
+      print("Error: Cannot find configuration \"" ..  configname .. ".lua\"")
       exit(1)
     end
   end


### PR DESCRIPTION
Using the latex3 repo (https://github.com/latex3/latex3) as an example,

- Before (https://github.com/latex3/latex3/actions/runs/4694269042/jobs/8322260846)
  ```
  Running l3build with target "check" for module l3kernel
  Running l3build with target "check" with configuration build
  ```
- After
  ```
  Running l3build with target "check" for module "l3kernel"
  Running l3build with target "check" and configuration "build"
  ```