### PR TITLE
Update a leftover doc for `unpackexe`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ this project uses date-based 'snapshot' version identifiers.
 ### Changed
 - Improve stdout "Running l3build with target ..."
 - Quote configuration name used in stdout
+- Update one leftover outdated doc for `unpackexe`. It defaults to `pdftex`.
 
 ## [2023-03-27]
 

--- a/l3build.dtx
+++ b/l3build.dtx
@@ -582,7 +582,7 @@
 % This is an internal target that is normally not needed on user level.
 % It unpacks all files into the directory defined by \var{unpackdir}. This occurs before other build commands such as |doc|, |check|, etc.
 %
-% The unpacking process is performed by executing the \var{unpackexe} (default \texttt{tex}) with options \var{unpackopts} on all files defined by the \var{unpackfiles} variable; by default, all files that match \luavar{unpackfiles}.
+% The unpacking process is performed by executing the \var{unpackexe} (default \texttt{pdftex}) with options \var{unpackopts} on all files defined by the \var{unpackfiles} variable; by default, all files that match \luavar{unpackfiles}.
 %
 % If additional support files are required for the unpacking process, these can be enumerated in the \var{unpacksuppfiles} variable.
 % Dependencies for unpacking are defined with \var{unpackdeps}.


### PR DESCRIPTION
It defaults to `pdftex` since release 2019-09-14,
commt 1c6879d (Use pdftex for unpacking, 2019-09-14)