### PR TITLE
Improve doc for stdengine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ this project uses date-based 'snapshot' version identifiers.
 - Building pLaTeX format now uses e-upTeX engine
 - Normalize more `luaotfload` path data (see issue \#301)
 - Update ConTeXt settings to allow for LuaTeX and LuaMetaTeX runs
+- Improve doc for default `stdengine`
 
 ### Fixed
 - Avoid setting `TEMXFCNF` for ConTeXt (issue \#232)

--- a/l3build.dtx
+++ b/l3build.dtx
@@ -111,7 +111,7 @@
 \luavarset{unpackdeps} {\{\}}{List of dependencies for unpacking}
 \luavarseparator
 \luavarset{checkengines}{\{"pdftex", "xetex", "luatex"\}}{Engines to check with \texttt{check} by default}
-\luavarset{stdengine}    {"pdftex"}{Engine to generate \texttt{.tlg} file from}
+\luavarset{stdengine}    {checkengines[1] or "pdftex"}{Engine to generate \texttt{.tlg} file from}
 \luavarset{checkformat}  {"latex"} {Format to use for tests}
 \luavarset{specialformats}{\meta{table}} {Non-standard engine/format combinations}
 \luavarset{\detokenize{test_types}}        {\meta{table}} {Custom test variants}


### PR DESCRIPTION
This PR updates doc for `stdengine`'s default value so it correctly reflects the corresponding code and the related doc newly added in  commit e47ee30 (Improve docs on stdengine, 2023-07-17).

https://github.com/latex3/l3build/blob/fce0f30d9c62e0e0307bb904ce1474fbf8978d45/l3build-variables.lua#L141