### PR TITLE
Revert "More minimisation"

### DIFF
--- a/.github/tl_packages
+++ b/.github/tl_packages
@@ -24,6 +24,7 @@ enumitem
 fancyvrb
 hologo
 hypdoc
+hyperref
 infwarerr
 iftex
 kvoptions


### PR DESCRIPTION
This reverts commit b3a8076a4fa6154fd3dc20c707ae19d868e8ae38.

hyperref _is_ required by hypdoc but the latter doesn't have its dependencies stored in TeX Live's svn repo yet.

Compare
 - `hypdoc.tlpsrc` https://www.tug.org/svn/texlive/trunk/Master/tlpkg/tlpsrc/hypdoc.tlpsrc?revision=67656&view=markup with
 - `hyperref.tlpsrc` https://www.tug.org/svn/texlive/trunk/Master/tlpkg/tlpsrc/hyperref.tlpsrc?revision=67656&view=markup

Because of TeX Live cache, commit b3a8076a4fa6154fd3dc20c707ae19d868e8ae38 didn't fail the CI in upstream, but did fail the CI in my fork, see https://github.com/muzimuzhi/l3build/actions/runs/5578945161, which failed with error
```
! LaTeX Error: File `intcalc.sty' not found.
```
Here `intcalc` is one of the dependencies of `hyperref` listed in `hyperref.tlpsrc`, and loaded by
```
l3build.dtx
  l3doc.cls
    alphalph.sty
      intcalc.sty
```
(Thus TeX Live's svn repo doesn't have list of dependencies of `alphalph` too.)
