### PR TITLE
Update action `actions/checkout` to v3

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       # Boilerplate
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       # GitHub Actions don't regenerate the test if the key doesn't change, so
       # we integrate a random UUID into the key to keep them different.
       # DO NOT CHANGE THIS


### PR DESCRIPTION
`actions/checkout@v2` uses node12 which is deprecated. See https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/.

This is leftover of my previous PR #272 (my bad), and I just spot it in a recent `deploy.yml` run https://github.com/latex3/l3build/actions/runs/5578708838.