### PR TITLE
Update deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -15,29 +15,10 @@ jobs:
       # Boilerplate
       - name: Checkout repository
         uses: actions/checkout@v3
-      # GitHub Actions don't regenerate the test if the key doesn't change, so
-      # we integrate a random UUID into the key to keep them different.
-      # DO NOT CHANGE THIS
-      - name: Generate unique ID
-        id: get-id
-        run: |
-          echo "id=$(cat /proc/sys/kernel/random/uuid)" >> $GITHUB_STATE
-      # Actually load the cache. Since we never reuse the key, we need restore-keys
-      # to indicate the prefix of our caches. This loads the newest cache with this
-      # prefix in the key.
-      #
-      # If we want to force regeneration of the cache, increase the number after
-      # *both* instances of "texlive-v"
-      - name: Load cache
-        uses: actions/cache@v3
-        with:
-          path: ~/texlive
-          key: texlive-v0-${{ steps.get-id.outputs.id }}
-          restore-keys: texlive-v0-
       # We need Ghostscript for XeTeX tests.
       - run: sudo apt-get update && sudo apt-get install ghostscript
       - name: Install TeX Live
-        uses: zauguin/install-texlive@v1
+        uses: zauguin/install-texlive@v2
         with:
           # List the required TeX Live packages in a separate file to allow reuse in
           # different workflows.
@@ -46,8 +27,7 @@ jobs:
         run: texlua l3build.lua ctan -H --show-log-on-error
       # Now create the release (this only runs if the previous steps were successful)
       - name: Create GitHub release
-        uses: ncipollo/release-action@880be3d0a71bc0fa98db60201d2cbdc27324f547
-        id: release
+        uses: ncipollo/release-action@a2e71bdd4e7dab70ca26a852f29600c98b33153e # v1.12.0
         with:
           artifacts: "build/distrib/ctan/*.zip"
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Update `zauguin/install-texlive` to v2 which integrates caching and is used by main workflow since commit 129159f (Update gh action `zauguin/install-texlive` to v2, 2023-02-20).
- Update `ncipollo/release-action` from old version (v1.8.6) using deprecated node12 to v1.12.0 using in support node16.

I should have put them in the last PR #309 as well. 😢 