### PR TITLE
Add ConTeXt to supported `checkformat`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Added
+- Document ConTeXt as supported `checkformat`
+
 ## [2023-09-07]
 
 ### Changed

--- a/l3build.dtx
+++ b/l3build.dtx
@@ -433,7 +433,8 @@
 % configurations are used and need adjustment to the standard engine, this does
 % need to be given explicitly using \var{stdengine}.
 % The format used for tests can be altered by setting \var{checkformat}: the default setting \texttt{latex} means that tests are run using \emph{e.g.}~\texttt{pdflatex}, whereas setting to \texttt{tex} will run tests using \emph{e.g.}~\texttt{pdftex}.
-% (Currently, this should be one of \texttt{latex} or \texttt{tex}.)
+% (Currently, this should be one of \texttt{latex}, \texttt{tex}, or
+% \texttt{context}.)
 % To perform the check, the engine typesets each test up to \var{checkruns} times.
 % More detail on this in the documentation on |save|.
 % Options passed to the binary are those defined in the variable
@@ -820,12 +821,13 @@
 % For more complex set ups, \var{specialformats} should be used. This is a
 % table with one entry per \var{checkformat}. Each entry is itself a table,
 % and these contain a list of engines and settings for |binary|, |format|
-% and |options|. For example, for Con\TeX{}t and appropriate set up is
+% and |options|. For example, the set up for Con\TeX{}t in \pkg{l3build} 2023-07-17 is
 % \begin{verbatim}
 % specialformats.context = {
-%   luatex = {binary = "context", format = ""},
-%   pdftex = {binary = "texexec", format = ""},
-%   xetex  = {binary = "texexec", format = "", options = "--xetex"}
+%   luametatex = {binary = "context", format = ""},
+%   luatex     = {binary = "context", format = "", options = "--luatex"},
+%   pdftex     = {binary = "texexec", format = ""},
+%   xetex      = {binary = "texexec", format = "", options = "--xetex"}
 % }
 % \end{verbatim}
 % Additional tokens can also be injected before the loading of a test file using


### PR DESCRIPTION
Is ConTeXt officially supported to be set as `checkformat`?  (If not I should revert the change about `checkformat`.) `l3build` already has
https://github.com/latex3/l3build/blob/1c6305444c724a0ca522fa5da2c60d8f87d7bc7f/l3build-variables.lua#L119-L124

The sub-table `specialformats.context` is contributed by commits e1f620a92e22beff2582ad25eb653ce5d2a50424 and 3de572897962f2465be59fccd41098f5125fee16.