### PR TITLE
Drop duplicate backslashes in doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Changed
+- Drop duplicate backslashes in doc
+
 ### Fixed
 - Support non-ASCII filenames that fall within the system codepage on Windows
   (see \#122)

--- a/l3build.dtx
+++ b/l3build.dtx
@@ -529,7 +529,7 @@
 % If the compilation is successful the |.pdf| is moved back into the main directory.
 %
 % The documentation compilation is performed with the \var{typesetexe} binary (default \texttt{pdflatex}), with options \var{typesetopts}.
-% Additional \TeX{} material defined in \var{typesetcmds} is passed to the document (e.g., for writing |\\PassOptionsToClass{l3doc}{letterpaper}|, and so on---note that backslashes need to be escaped in Lua strings).
+% Additional \TeX{} material defined in \var{typesetcmds} is passed to the document (e.g., for writing |\PassOptionsToClass{l3doc}{letterpaper}|, and so on---note that backslashes need to be escaped in Lua strings).
 %
 % Files that match |typesetsuppfiles| in the |support| directory (|supportdir|) are copied into the |build/doc| directory (|typesetdir|) for the typesetting compilation process.
 % Additional dependencies listed in the \var{typesetdeps} variable (empty by default) will also be installed.
@@ -1819,7 +1819,7 @@
 %     |normalize_path(|\meta{path}|)|
 %   \end{syntax}
 %   When called on Windows, returns a string comprising the \meta{path} with
-%   |/| characters replaced by |\\|. In other cases returns the path unchanged.
+%   |/| characters replaced by |\|. In other cases returns the path unchanged.
 % \end{function}
 %
 % \subsection{System-dependent strings}


### PR DESCRIPTION
Before
- ![image](https://github.com/latex3/l3build/assets/6376638/aaca12c8-3010-45b5-a127-4c724442b7f2)
- ![image](https://github.com/latex3/l3build/assets/6376638/e1f3dd36-6ea7-4708-bde6-0e41ee9cb732)

After
- ![image](https://github.com/latex3/l3build/assets/6376638/f1b3b634-4b9f-40cc-b2f5-7a01350fbd59)
- ![image](https://github.com/latex3/l3build/assets/6376638/e3291efa-9c65-43ad-9d21-142607883993)
