### PR TITLE
Minor doc improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Changed
+- Document default value of `ctanpkg` as a valid lua expression
+
 ## [2023-11-01]
 
 ### Changed

--- a/l3build.dtx
+++ b/l3build.dtx
@@ -52,7 +52,7 @@
 \def\allluavars{
 \luavarset{module}{""}{The name of the module}
 \luavarset{bundle}{""}{The name of the bundle in which the module belongs (where relevant)}
-\luavarset{ctanpkg}{module/bundle}{Name of the CTAN package matching this module}
+\luavarset{ctanpkg}{bundle == "" and module or bundle}{Name of the CTAN package matching this module}
 \luavarseparator
 \luavarset{modules}{\{\}}{The list of all modules in a bundle (when not auto-detecting)}
 \luavarset{exclmodules}{\{\}}{Directories to be excluded from automatic module detection}

--- a/l3build.dtx
+++ b/l3build.dtx
@@ -54,8 +54,8 @@
 \luavarset{bundle}{""}{The name of the bundle in which the module belongs (where relevant)}
 \luavarset{ctanpkg}{bundle == "" and module or bundle}{Name of the CTAN package matching this module}
 \luavarseparator
-\luavarset{modules}{\{\}}{The list of all modules in a bundle (when not auto-detecting)}
-\luavarset{exclmodules}{\{\}}{Directories to be excluded from automatic module detection}
+\luavarset{modules}{\{ \}}{The list of all modules in a bundle (when not auto-detecting)}
+\luavarset{exclmodules}{\{ \}}{Directories to be excluded from automatic module detection}
 \luavarseparator
 \luavarset{maindir}     {"."}                      {Top level directory for the module/bundle}
 \luavarset{docfiledir}  {"."}                 {Directory containing documentation files}
@@ -85,8 +85,8 @@
 \luavarset{checkfiles}        {\{~\}}{Extra files unpacked purely for tests}
 \luavarset{checksuppfiles}    { }{Files needed for performing regression tests}
 \luavarset{cleanfiles}        {\{"*.log", "*.pdf", "*.zip"\}}{Files to delete when cleaning}
-\luavarset{demofiles}         {\{\}}{Files which show how to use a module}
-\luavarset{docfiles}          {\{\}}{Files which are part of the documentation but should not be typeset}
+\luavarset{demofiles}         {\{ \}}{Files which show how to use a module}
+\luavarset{docfiles}          {\{ \}}{Files which are part of the documentation but should not be typeset}
 \luavarset{dynamicfiles}      {\{ \}}{Secondary files to cleared before each test is run}
 \luavarset{excludefiles}      {\{"*\string~","build.lua","config-*.lua"\}}{Files to ignore entirely (default for Emacs backup files)}
 \luavarset{installfiles}      {\{"*.sty","*.cls"\}}{Files to install to the \texttt{tex} area of the \texttt{texmf} tree}
@@ -96,19 +96,19 @@
 \luavarset{sourcefiles}       {\{"*.dtx", "*.ins", "*-????-??-??.sty"\}}{Files to copy for unpacking}
 \luavarset{tagfiles}          {\{"*.dtx"\}}{Files for automatic tagging}
 \luavarset{textfiles}         {\{"*.md", "*.txt"\}}{Plain text files to send to CTAN as-is}
-\luavarset{typesetdemofiles}  {\{\}}{Files to typeset before the documentation for inclusion in main documentation files}
+\luavarset{typesetdemofiles}  {\{ \}}{Files to typeset before the documentation for inclusion in main documentation files}
 \luavarset{typesetfiles}      {\{"*.dtx"\}}{Files to typeset for documentation}
-\luavarset{typesetsuppfiles}  {\{\}}{Files needed to support typesetting when \enquote{sandboxed}}
-\luavarset{typesetsourcefiles}{\{\}}{Files to copy to unpacking when typesetting}
+\luavarset{typesetsuppfiles}  {\{ \}}{Files needed to support typesetting when \enquote{sandboxed}}
+\luavarset{typesetsourcefiles}{\{ \}}{Files to copy to unpacking when typesetting}
 \luavarset{unpackfiles}       {\{"*.ins"\}}{Files to run to perform unpacking}
-\luavarset{unpacksuppfiles}   {\{\}}{Files needed to support unpacking when \enquote{sandboxed}}
+\luavarset{unpacksuppfiles}   {\{ \}}{Files needed to support unpacking when \enquote{sandboxed}}
 \luavarseparator
 \luavarset{includetests}{\{"*"\}}{Test names to include when checking}
-\luavarset{excludetests}{\{\}}   {Test names to exclude when checking}
+\luavarset{excludetests}{\{ \}}   {Test names to exclude when checking}
 \luavarseparator
-\luavarset{checkdeps}  {\{\}}{List of dependencies for running checks}
-\luavarset{typesetdeps}{\{\}}{List of dependencies for typesetting docs}
-\luavarset{unpackdeps} {\{\}}{List of dependencies for unpacking}
+\luavarset{checkdeps}  {\{ \}}{List of dependencies for running checks}
+\luavarset{typesetdeps}{\{ \}}{List of dependencies for typesetting docs}
+\luavarset{unpackdeps} {\{ \}}{List of dependencies for unpacking}
 \luavarseparator
 \luavarset{checkengines}{\{"pdftex", "xetex", "luatex"\}}{Engines to check with \texttt{check} by default}
 \luavarset{stdengine}    {checkengines[1] or "pdftex"}{Engine to generate \texttt{.tlg} file from}
@@ -117,7 +117,7 @@
 \luavarset{\detokenize{test_types}}        {\meta{table}} {Custom test variants}
 \luavarset{\detokenize{test_order}}        {\{"log", "pdf"\}} {Which kinds of tests to evaluate}
 \luavarseparator
-\luavarset{checkconfigs}{\{\}}{Configurations to use for tests}
+\luavarset{checkconfigs}{\{ \}}{Configurations to use for tests}
 \luavarseparator
 \luavarset{typesetexe}   {"pdflatex"} {Executable for compiling \texttt{doc(s)}}
 \luavarset{unpackexe}    {"pdftex"}   {Executable for running \texttt{unpack}}

--- a/l3build.dtx
+++ b/l3build.dtx
@@ -190,7 +190,7 @@
   \setlength\LTleft{-0.21\linewidth}
   \begin{longtable}{@{}%
     >{\small}
-    p{0.18\linewidth}
+    p{0.20\linewidth}
     @{\hspace{0.03\linewidth}}
     >{\footnotesize\hangindent=1em}
     p{0.34\linewidth}


### PR DESCRIPTION
About the change that widens the first column in the big table:
- Before (release 2023-09-13)
  ![image](https://github.com/latex3/l3build/assets/6376638/05170308-671d-4458-bcc2-e4fe087b094c)
  ![image](https://github.com/latex3/l3build/assets/6376638/d8d560ea-0cd0-45d6-b93a-4150a072fdbe)
- After
  ![image](https://github.com/latex3/l3build/assets/6376638/ab8838e9-11e2-44e0-abf3-dc3c4b543c93)
  ![image](https://github.com/latex3/l3build/assets/6376638/9bd89504-a546-4899-9a07-48423f7055c5)

As the `longtable` is typeset with setting `\setlength\LTleft{-0.21\linewidth}`, I suppose no following columns need be narrowed down.