### PR TITLE
Short-circuit `check --rerun` if `testdir` doesn't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ this project uses date-based 'snapshot' version identifiers.
 ### Changed
 - Document default value of `ctanpkg` as a valid lua expression
 
+### Fixed
+- Short-circuit `check --rerun` if `testdir` doesn't exist
+
 ## [2023-11-01]
 
 ### Changed

--- a/l3build-check.lua
+++ b/l3build-check.lua
@@ -926,7 +926,13 @@ end
 function check(names)
   local errorlevel = 0
   if testfiledir ~= "" and direxists(testfiledir) then
-    if not options["rerun"] then
+    if options["rerun"] then
+      if not direxists(testdir) then
+        print("\n  Test directory \"" .. testdir .. "\" doesn't exist.")
+        print("  Try again without \"--rerun\".\n")
+        return 1
+      end
+    else
       errorlevel = checkinit()
       if errorlevel ~= 0 then
         return errorlevel


### PR DESCRIPTION
When corresponding `testdir` doesn't exist, currently `l3build check --rerun` exits with all `testdir`s created as files in `builddir`, not as directories.

Unfortunately a following `l3build check` without `--rerun` won't reset this wrong state, because none of `mkdir()` and `cleandir()` ensures the the created/cleaned object is a directory. Thus user has to clean `builddir` manually to recover from the problem.

This PR adds a guard to `check()` so that `l3build check --rerun` will complain and short-circuit when the corresponding `testdir` doesn't exist.

- Before
    ```bash
    $ git clone git@github.com:latex3/l3build.git && cd l3build
    # specify a config file to get shorter stdout/stderr
    $ texlua ./l3build check -c build --rerun
    Running checks on
      00-test-1 (1/1)
    ./l3build-file-functions.lua:184: Unable to change working directory to './build/test'
    Not a directory
    $ tree build
    build
    └── test
    
    1 directory, 1 file
    ```
    Note the `./build/test` is created as a file, not a directory.
- After
    ```shell
    $ texlua ./l3build.lua check --rerun -c build
    
      Test directory "./build/test" doesn't exist. Try again without "--rerun".
    $ tree build
    build  [error opening dir]
    
    0 directories, 0 files
    ```
    Without `-c build`
    ```bash
    $ texlua ./l3build.lua check --rerun
    Running l3build with target "check" and configuration "build"
    
      Test directory "./build/test" doesn't exist. Try again without "--rerun".
    
    Running l3build with target "check" and configuration "config-pdf"
    
      Test directory "./build/test-config-pdf" doesn't exist. Try again without "--rerun".
    
    Running l3build with target "check" and configuration "config-plain"
    
      Test directory "./build/test-config-plain" doesn't exist. Try again without "--rerun".
    
    Running l3build with target "check" and configuration "config-context"
    
      Test directory "./build/test-config-context" doesn't exist. Try again without "--rerun".
    
    Failed tests for configuration "build":
    
      Check failed with difference files
    
    ...

    $ tree build
    build  [error opening dir]

    0 directories, 0 files
    ```