### PR TITLE
Improve log for failed checks with no diff files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ this project uses date-based 'snapshot' version identifiers.
 
 ### Changed
 - Document default value of `ctanpkg` as a valid lua expression
+- Improve log for failed checks with no diff files
 
 ## [2023-11-01]
 

--- a/l3build-check.lua
+++ b/l3build-check.lua
@@ -1031,7 +1031,7 @@ function check(names)
       end
     end
     if errorlevel ~= 0 then
-      checkdiff()
+      checkdiff() -- this leaves "config" parameter of "checkdiff()" nil
       if options["show-saves"] then
         showsavecommands(failurelist)
       end
@@ -1043,10 +1043,26 @@ function check(names)
 end
 
 -- A short auxiliary to print the list of differences for check
-function checkdiff()
-  print("\n  Check failed with difference files")
-  for _,i in ipairs(ordered_filelist(testdir, "*" .. os_diffext)) do
-    print("  - " .. testdir .. "/" .. i)
+function checkdiff(config)
+  local diff_files = ordered_filelist(testdir, "*" .. os_diffext)
+  if next(diff_files) then
+    if config then
+      print("Failed tests for configuration \"" .. config .. "\":")
+      local testdir = testdir
+      if config ~= "build" then
+        testdir = testdir .. "-" .. config
+      end
+    end
+    print("\n  Check failed with difference files")
+    for _,i in ipairs(diff_files) do
+      print("  - " .. testdir .. "/" .. i)
+    end
+  else
+    if config then
+      print("Check failed for configuration \"" .. config .. "\" with no difference files.")
+    else
+      print("Check failed with no difference files.")
+    end
   end
   print("")
 end

--- a/l3build.lua
+++ b/l3build.lua
@@ -165,16 +165,7 @@ if #checkconfigs > 1 then
     end
     if next(failed) then
       for _,config in ipairs(failed) do
-        print("Failed tests for configuration \"" .. config .. "\":")
-        print("\n  Check failed with difference files")
-        local testdir = testdir
-        if config ~= "build" then
-          testdir = testdir .. "-" .. config
-        end
-        for _,i in ipairs(ordered_filelist(testdir,"*" .. os_diffext)) do
-          print("  - " .. testdir .. "/" .. i)
-        end
-        print("")
+        checkdiff(config)
       end
       if options["show-saves"] then
         local savecmds, recheckcmds = "", ""


### PR DESCRIPTION
In a clean `l3build` repository,
- executing `texlua ./l3build.lua check undefined-test`, the last lines of stdout are
  - before
    ```
    Running checks on
      undefined-test (1/1)
    Failed to find input for test undefined-test
              --> failed
    
    
      Check failed with difference files

    ```
  - after
    ```
    Failed to find input for test undefined-test
              --> failed
    
    Check failed with no difference files.

    ```
- executing `texlua ./l3build.lua check --rerun undefined-test`, the last lines of stdout are
  - before
    ```
    Failed tests for configuration "build":
    
      Check failed with difference files
    
    Failed tests for configuration "config-pdf":
    
      Check failed with difference files
    
    Failed tests for configuration "config-plain":
    
      Check failed with difference files
    
    Failed tests for configuration "config-context":
    
      Check failed with difference files

    ```
  - after
    ```
    Check failed for configuration "build" with no difference files.
    
    Check failed for configuration "config-pdf" with no difference files.
    
    Check failed for configuration "config-plain" with no difference files.
    
    Check failed for configuration "config-context" with no difference files.

    ```