### PR TITLE
Update actions in `deploy.yaml` and add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -14,11 +14,11 @@ jobs:
     steps:
       # Boilerplate
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # We need Ghostscript for XeTeX tests.
       - run: sudo apt-get update && sudo apt-get install ghostscript
       - name: Install TeX Live
-        uses: zauguin/install-texlive@v2
+        uses: zauguin/install-texlive@v3
         with:
           # List the required TeX Live packages in a separate file to allow reuse in
           # different workflows.
@@ -29,7 +29,7 @@ jobs:
         run: texlua l3build.lua ctan -H --show-log-on-error
       # Now create the release (this only runs if the previous steps were successful)
       - name: Create GitHub release
-        uses: ncipollo/release-action@a2e71bdd4e7dab70ca26a852f29600c98b33153e # v1.12.0
+        uses: ncipollo/release-action@v1
         with:
           artifacts: "build/distrib/ctan/*.zip"
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Update actions in `deploy.yaml` (#318 only updated that for `main.yaml`)
  - Bump actions/checkout from 3 to 4
  - Bump zauguin/install-texlive from 2 to 3
  - Reference major version of ncipollo/release-action
    The development of this action should be stable now, hence no need to reference its specific commit.
    https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsuses
- Add dependabot
  This won't take effect until dependabot version updates is enabled in a per-repository manner, see [GitHub Docs](https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates#enabling-version-updates-on-forks).