### PR TITLE
Document syntax of `\SHOWFILE` and `\ASSERT(STR)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ this project uses date-based 'snapshot' version identifiers.
 ### Changed
 - Document default value of `ctanpkg` as a valid lua expression
 - Improve log for failed checks with no diff files
+- Document full syntaxes of `\SHOWFILE` and `\ASSERT(STR)`
 
 ### Fixed
 - Short-circuit `check --rerun` if `testdir` doesn't exist

--- a/l3build.dtx
+++ b/l3build.dtx
@@ -977,12 +977,13 @@
 % \cs{BEGINTEST}\marg{title} \dots \cs{ENDTEST} is an environment form of
 % \cs{TEST}, allowing verbatim material, \emph{etc.} to appear.
 % \item
-% \cs{SHOWFILE} (\eTeX{} only) Shows the content of the file given as an
-% argument.
+% \cs{SHOWFILE}\marg{filename} (\eTeX{} only) Shows the content of
+% \meta{filename}.
 % \item
-% \cs{ASSERT} and \cs{ASSERTSTR} Asserts if the full expansion
-% of the two required arguments are the same: the \cs{ASSERT} function is
-% token-based, the \cs{ASSERTSTR} works on a string basis.
+% \cs{ASSERT}\marg{arg_1}\marg{arg_2} and \cs{ASSERTSTR}\marg{arg_1}\marg{arg_2}
+% Asserts if the full expansion of \meta{arg_1} and \meta{arg_2} are the same:
+% the \cs{ASSERT} function is token-based,
+% the \cs{ASSERTSTR} works on a string basis.
 % \end{itemize}
 % An example of some of these commands is shown following.
 % \begin{Verbatim}


### PR DESCRIPTION
I think syntaxes are preferable than textual descriptions.

Before
![image](https://github.com/latex3/l3build/assets/6376638/4c77147c-23dd-4b6d-b01e-324d89ef8cf0)
After
![image](https://github.com/latex3/l3build/assets/6376638/e5d06a09-21e6-4f82-9848-b1b36a6908dc)

