### PR TITLE
Update copyright

### DIFF
--- a/build.lua
+++ b/build.lua
@@ -18,7 +18,14 @@ sourcefiles  = {"*.dtx", "l3build*.lua", "*.ins"}
 typesetruns  = 4
 typesetcmds  = "\\AtBeginDocument{\\DisableImplementation}"
 unpackdeps   = { }
-tagfiles     = {"l3build.1", "l3build.dtx", "*.md", "l3build.lua"}
+tagfiles     = {
+  "l3build.1",
+  "l3build.dtx",
+  "l3build.ins",
+  "**/*.md",     -- to include README.md in ./examples
+  "l3build*.lua",
+  "**/regression-test.cfg"
+}
 
 uploadconfig = {
   author      = "The LaTeX Team",
@@ -42,6 +49,21 @@ Linux, macOS, and Windows systems. The package offers:
 function update_tag(file,content,tagname,tagdate)
   local iso = "%d%d%d%d%-%d%d%-%d%d"
   local url = "https://github.com/latex3/l3build/compare/"
+  -- update copyright
+  -- copied from https://github.com/latex3/latex3/blob/76104b03a42246726556384f2ca34083bc6955aa/build-config.lua#L48-L60
+  if string.match(content,"%(C%)%s*[%d%-,]+ The LaTeX Project") then
+    local year = os.date("%Y")
+    content = string.gsub(content,
+      "%(C%)%s*([%d%-,]+) The LaTeX Project",
+      "(C) %1," .. year .. " The LaTeX Project")
+    content = string.gsub(content,year .. "," .. year,year)
+    content = string.gsub(content,
+      "%-" .. math.tointeger(year - 1) .. "," .. year,
+      "-" .. year)
+    content = string.gsub(content,
+      math.tointeger(year - 2) .. "," .. math.tointeger(year - 1) .. "," .. year,
+      math.tointeger(year - 2) .. "-" .. year)
+  end
   if string.match(file, "%.1$") then
     return string.gsub(content,
       '%.TH l3build 1 "' .. iso .. '"\n',

--- a/build.lua
+++ b/build.lua
@@ -50,20 +50,17 @@ function update_tag(file,content,tagname,tagdate)
   local iso = "%d%d%d%d%-%d%d%-%d%d"
   local url = "https://github.com/latex3/l3build/compare/"
   -- update copyright
-  -- copied from https://github.com/latex3/latex3/blob/76104b03a42246726556384f2ca34083bc6955aa/build-config.lua#L48-L60
-  if string.match(content,"%(C%)%s*[%d%-,]+ The LaTeX Project") then
-    local year = os.date("%Y")
+  local year = os.date("%Y")
+  if string.match(content,"%(C%)%s*" .. (year - 1) .. " The LaTeX Project") then
     content = string.gsub(content,
-      "%(C%)%s*([%d%-,]+) The LaTeX Project",
-      "(C) %1," .. year .. " The LaTeX Project")
-    content = string.gsub(content,year .. "," .. year,year)
+      "%(C%)%s*" .. (year - 1) .. " The LaTeX Project",
+      "(C) " .. year .. " The LaTeX Project")
+  elseif string.match(content,"%(C%)%s*%d%d%d%d%-" .. (year - 1) .. " The LaTeX Project") then
     content = string.gsub(content,
-      "%-" .. math.tointeger(year - 1) .. "," .. year,
-      "-" .. year)
-    content = string.gsub(content,
-      math.tointeger(year - 2) .. "," .. math.tointeger(year - 1) .. "," .. year,
-      math.tointeger(year - 2) .. "-" .. year)
+      "%(C%)%s*(%d%d%d%d%-)" .. (year - 1) .. " The LaTeX Project",
+      "(C) %1" .. year .. " The LaTeX Project")
   end
+  -- update release date
   if string.match(file, "%.1$") then
     return string.gsub(content,
       '%.TH l3build 1 "' .. iso .. '"\n',

--- a/examples/Bundle-Flat/README.md
+++ b/examples/Bundle-Flat/README.md
@@ -10,6 +10,6 @@ in the build script for each module.
 
 -----
 
-Copyright (C) 2014-2017,2021,2023 The LaTeX Project <br />
+Copyright (C) 2014-2023 The LaTeX Project <br />
 <http://latex-project.org/> <br />
 All rights reserved.

--- a/examples/Bundle-Flat/README.md
+++ b/examples/Bundle-Flat/README.md
@@ -10,6 +10,6 @@ in the build script for each module.
 
 -----
 
-Copyright (C) 2014-2017,2021 The LaTeX Project <br />
+Copyright (C) 2014-2017,2021,2023 The LaTeX Project <br />
 <http://latex-project.org/> <br />
 All rights reserved.

--- a/examples/Bundle-Tree/README.md
+++ b/examples/Bundle-Tree/README.md
@@ -10,6 +10,6 @@ in the build script for each module.
 
 -----
 
-Copyright (C) 2014-2017,2021,2023 The LaTeX Project <br />
+Copyright (C) 2014-2023 The LaTeX Project <br />
 <http://latex-project.org/> <br />
 All rights reserved.

--- a/examples/Bundle-Tree/README.md
+++ b/examples/Bundle-Tree/README.md
@@ -10,6 +10,6 @@ in the build script for each module.
 
 -----
 
-Copyright (C) 2014-2017,2021 The LaTeX Project <br />
+Copyright (C) 2014-2017,2021,2023 The LaTeX Project <br />
 <http://latex-project.org/> <br />
 All rights reserved.

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,6 +19,6 @@ The examples are:
 
 -----
 
-Copyright (C) 2014-2017,2021,2023 The LaTeX Project <br />
+Copyright (C) 2014-2023 The LaTeX Project <br />
 <http://latex-project.org/> <br />
 All rights reserved.

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,6 +19,6 @@ The examples are:
 
 -----
 
-Copyright (C) 2014-2017,2021 The LaTeX Project <br />
+Copyright (C) 2014-2017,2021,2023 The LaTeX Project <br />
 <http://latex-project.org/> <br />
 All rights reserved.

--- a/examples/Simple-Flat/README.md
+++ b/examples/Simple-Flat/README.md
@@ -11,6 +11,6 @@ As the `.dtx` package file grows larger, it may be sensible to split it up into 
 
 -----
 
-Copyright (C) 2014-2017,2021 The LaTeX Project <br />
+Copyright (C) 2014-2017,2021,2023 The LaTeX Project <br />
 <http://latex-project.org/> <br />
 All rights reserved.

--- a/examples/Simple-Flat/README.md
+++ b/examples/Simple-Flat/README.md
@@ -11,6 +11,6 @@ As the `.dtx` package file grows larger, it may be sensible to split it up into 
 
 -----
 
-Copyright (C) 2014-2017,2021,2023 The LaTeX Project <br />
+Copyright (C) 2014-2023 The LaTeX Project <br />
 <http://latex-project.org/> <br />
 All rights reserved.

--- a/examples/Simple-Tree/README.md
+++ b/examples/Simple-Tree/README.md
@@ -10,6 +10,6 @@ This is left as an exercise to the energetic package writer studying these examp
 
 -----
 
-Copyright (C) 2014-2017,2021 The LaTeX Project <br />
+Copyright (C) 2014-2017,2021,2023 The LaTeX Project <br />
 <http://latex-project.org/> <br />
 All rights reserved.

--- a/examples/Simple-Tree/README.md
+++ b/examples/Simple-Tree/README.md
@@ -10,6 +10,6 @@ This is left as an exercise to the energetic package writer studying these examp
 
 -----
 
-Copyright (C) 2014-2017,2021,2023 The LaTeX Project <br />
+Copyright (C) 2014-2023 The LaTeX Project <br />
 <http://latex-project.org/> <br />
 All rights reserved.

--- a/l3build-arguments.lua
+++ b/l3build-arguments.lua
@@ -1,6 +1,6 @@
 --[[
 
-File l3build-arguments.lua Copyright (C) 2018-2021,2023 The LaTeX Project
+File l3build-arguments.lua Copyright (C) 2018-2023 The LaTeX Project
 
 It may be distributed and/or modified under the conditions of the
 LaTeX Project Public License (LPPL), either version 1.3c of this

--- a/l3build-aux.lua
+++ b/l3build-aux.lua
@@ -1,6 +1,6 @@
 --[[
 
-File l3build-aux.lua Copyright (C) 2018-2021,2023 The LaTeX Project
+File l3build-aux.lua Copyright (C) 2018-2023 The LaTeX Project
 
 It may be distributed and/or modified under the conditions of the
 LaTeX Project Public License (LPPL), either version 1.3c of this

--- a/l3build-clean.lua
+++ b/l3build-clean.lua
@@ -1,6 +1,6 @@
 --[[
 
-File l3build-clean.lua Copyright (C) 2018,2020,2021,2023 The LaTeX Project
+File l3build-clean.lua Copyright (C) 2018-2023 The LaTeX Project
 
 It may be distributed and/or modified under the conditions of the
 LaTeX Project Public License (LPPL), either version 1.3c of this

--- a/l3build-clean.lua
+++ b/l3build-clean.lua
@@ -1,6 +1,6 @@
 --[[
 
-File l3build-clean.lua Copyright (C) 2018,2020,2021 The LaTeX Project
+File l3build-clean.lua Copyright (C) 2018,2020,2021,2023 The LaTeX Project
 
 It may be distributed and/or modified under the conditions of the
 LaTeX Project Public License (LPPL), either version 1.3c of this

--- a/l3build-ctan.lua
+++ b/l3build-ctan.lua
@@ -1,6 +1,6 @@
 --[[
 
-File l3build-ctan.lua Copyright (C) 2018-2021,2023 The LaTeX Project
+File l3build-ctan.lua Copyright (C) 2018-2023 The LaTeX Project
 
 It may be distributed and/or modified under the conditions of the
 LaTeX Project Public License (LPPL), either version 1.3c of this

--- a/l3build-ctan.lua
+++ b/l3build-ctan.lua
@@ -1,6 +1,6 @@
 --[[
 
-File l3build-ctan.lua Copyright (C) 2018-2021 The LaTeX Project
+File l3build-ctan.lua Copyright (C) 2018-2021,2023 The LaTeX Project
 
 It may be distributed and/or modified under the conditions of the
 LaTeX Project Public License (LPPL), either version 1.3c of this

--- a/l3build-help.lua
+++ b/l3build-help.lua
@@ -1,6 +1,6 @@
 --[[
 
-File l3build-help.lua Copyright (C) 2018,2020,2021,2023 The LaTeX Project
+File l3build-help.lua Copyright (C) 2018-2023 The LaTeX Project
 
 It may be distributed and/or modified under the conditions of the
 LaTeX Project Public License (LPPL), either version 1.3c of this
@@ -27,7 +27,7 @@ local match  = string.match
 local rep    = string.rep
 local sort   = table.sort
 
-local copyright = "Copyright (C) 2014-2021,2023 The LaTeX Project\n"
+local copyright = "Copyright (C) 2014-2023 The LaTeX Project\n"
 
 function version()
   print(

--- a/l3build-help.lua
+++ b/l3build-help.lua
@@ -1,6 +1,6 @@
 --[[
 
-File l3build-help.lua Copyright (C) 2018,2020,2021 The LaTeX Project
+File l3build-help.lua Copyright (C) 2018,2020,2021,2023 The LaTeX Project
 
 It may be distributed and/or modified under the conditions of the
 LaTeX Project Public License (LPPL), either version 1.3c of this
@@ -27,7 +27,7 @@ local match  = string.match
 local rep    = string.rep
 local sort   = table.sort
 
-local copyright = "Copyright (C) 2014-2021 The LaTeX Project\n"
+local copyright = "Copyright (C) 2014-2021,2023 The LaTeX Project\n"
 
 function version()
   print(

--- a/l3build-install.lua
+++ b/l3build-install.lua
@@ -1,6 +1,6 @@
 --[[
 
-File l3build-install.lua Copyright (C) 2018-2021 The LaTeX Project
+File l3build-install.lua Copyright (C) 2018-2023 The LaTeX Project
 
 It may be distributed and/or modified under the conditions of the
 LaTeX Project Public License (LPPL), either version 1.3c of this

--- a/l3build-manifest-setup.lua
+++ b/l3build-manifest-setup.lua
@@ -1,6 +1,6 @@
 --[[
 
-File l3build-manifest-setup.lua Copyright (C) 2018,2020,2021,2023 The LaTeX Project
+File l3build-manifest-setup.lua Copyright (C) 2018-2023 The LaTeX Project
 
 It may be distributed and/or modified under the conditions of the
 LaTeX Project Public License (LPPL), either version 1.3c of this

--- a/l3build-manifest-setup.lua
+++ b/l3build-manifest-setup.lua
@@ -1,6 +1,6 @@
 --[[
 
-File l3build-manifest-setup.lua Copyright (C) 2018,2020,2021 The LaTeX Project
+File l3build-manifest-setup.lua Copyright (C) 2018,2020,2021,2023 The LaTeX Project
 
 It may be distributed and/or modified under the conditions of the
 LaTeX Project Public License (LPPL), either version 1.3c of this

--- a/l3build-manifest.lua
+++ b/l3build-manifest.lua
@@ -1,6 +1,6 @@
 --[[
 
-File l3build-manifest.lua Copyright (C) 2018,2020,2021 The LaTeX Project
+File l3build-manifest.lua Copyright (C) 2018,2020-2023 The LaTeX Project
 
 It may be distributed and/or modified under the conditions of the
 LaTeX Project Public License (LPPL), either version 1.3c of this

--- a/l3build-manifest.lua
+++ b/l3build-manifest.lua
@@ -1,6 +1,6 @@
 --[[
 
-File l3build-manifest.lua Copyright (C) 2018,2020-2023 The LaTeX Project
+File l3build-manifest.lua Copyright (C) 2018-2023 The LaTeX Project
 
 It may be distributed and/or modified under the conditions of the
 LaTeX Project Public License (LPPL), either version 1.3c of this

--- a/l3build-stdmain.lua
+++ b/l3build-stdmain.lua
@@ -1,6 +1,6 @@
 --[[
 
-File l3build-stdmain.lua Copyright (C) 2018-2021,2023 The LaTeX Project
+File l3build-stdmain.lua Copyright (C) 2018-2023 The LaTeX Project
 
 It may be distributed and/or modified under the conditions of the
 LaTeX Project Public License (LPPL), either version 1.3c of this

--- a/l3build-stdmain.lua
+++ b/l3build-stdmain.lua
@@ -1,6 +1,6 @@
 --[[
 
-File l3build-stdmain.lua Copyright (C) 2018-2021 The LaTeX Project
+File l3build-stdmain.lua Copyright (C) 2018-2021,2023 The LaTeX Project
 
 It may be distributed and/or modified under the conditions of the
 LaTeX Project Public License (LPPL), either version 1.3c of this

--- a/l3build-tagging.lua
+++ b/l3build-tagging.lua
@@ -1,6 +1,6 @@
 --[[
 
-File l3build-tagging.lua Copyright (C) 2018-2021,2023 The LaTeX Project
+File l3build-tagging.lua Copyright (C) 2018-2023 The LaTeX Project
 
 It may be distributed and/or modified under the conditions of the
 LaTeX Project Public License (LPPL), either version 1.3c of this

--- a/l3build-tagging.lua
+++ b/l3build-tagging.lua
@@ -1,6 +1,6 @@
 --[[
 
-File l3build-tagging.lua Copyright (C) 2018-2021 The LaTeX Project
+File l3build-tagging.lua Copyright (C) 2018-2021,2023 The LaTeX Project
 
 It may be distributed and/or modified under the conditions of the
 LaTeX Project Public License (LPPL), either version 1.3c of this

--- a/l3build-typesetting.lua
+++ b/l3build-typesetting.lua
@@ -1,6 +1,6 @@
 --[[
 
-File l3build-typesetting.lua Copyright (C) 2018-2021,2023 The LaTeX Project
+File l3build-typesetting.lua Copyright (C) 2018-2023 The LaTeX Project
 
 It may be distributed and/or modified under the conditions of the
 LaTeX Project Public License (LPPL), either version 1.3c of this

--- a/l3build-unpack.lua
+++ b/l3build-unpack.lua
@@ -1,6 +1,6 @@
 --[[
 
-File l3build-unpack.lua Copyright (C) 2018-2021 The LaTeX Project
+File l3build-unpack.lua Copyright (C) 2018-2021,2023 The LaTeX Project
 
 It may be distributed and/or modified under the conditions of the
 LaTeX Project Public License (LPPL), either version 1.3c of this

--- a/l3build-unpack.lua
+++ b/l3build-unpack.lua
@@ -1,6 +1,6 @@
 --[[
 
-File l3build-unpack.lua Copyright (C) 2018-2021,2023 The LaTeX Project
+File l3build-unpack.lua Copyright (C) 2018-2023 The LaTeX Project
 
 It may be distributed and/or modified under the conditions of the
 LaTeX Project Public License (LPPL), either version 1.3c of this

--- a/l3build-upload.lua
+++ b/l3build-upload.lua
@@ -1,6 +1,6 @@
 --[[
 
-File l3build-upload.lua Copyright (C) 2018-2021 The LaTeX Project
+File l3build-upload.lua Copyright (C) 2018-2023 The LaTeX Project
 
 It may be distributed and/or modified under the conditions of the
 LaTeX Project Public License (LPPL), either version 1.3c of this

--- a/l3build-zip.lua
+++ b/l3build-zip.lua
@@ -1,6 +1,6 @@
 --[[
 
-File l3build-zip.lua Copyright (C) 2021 The LaTeX Project
+File l3build-zip.lua Copyright (C) 2021,2023 The LaTeX Project
 
 It may be distributed and/or modified under the conditions of the
 LaTeX Project Public License (LPPL), either version 1.3c of this

--- a/l3build-zip.lua
+++ b/l3build-zip.lua
@@ -1,6 +1,6 @@
 --[[
 
-File l3build-zip.lua Copyright (C) 2021,2023 The LaTeX Project
+File l3build-zip.lua Copyright (C) 2021-2023 The LaTeX Project
 
 It may be distributed and/or modified under the conditions of the
 LaTeX Project Public License (LPPL), either version 1.3c of this

--- a/l3build.ins
+++ b/l3build.ins
@@ -1,6 +1,6 @@
 \iffalse meta-comment
 
-File l3build.ins Copyright (C) 2014-2018,2021 The LaTeX Project
+File l3build.ins Copyright (C) 2014-2018,2021,2023 The LaTeX Project
 
 It may be distributed and/or modified under the conditions of the
 LaTeX Project Public License (LPPL), either version 1.3c of this
@@ -32,7 +32,7 @@ license information is placed in the derived files.
 
 \preamble
 
-Copyright (C) 2014-2021 The LaTeX Project
+Copyright (C) 2014-2021,2023 The LaTeX Project
 
 It may be distributed and/or modified under the conditions of
 the LaTeX Project Public License (LPPL), either version 1.3c of

--- a/l3build.ins
+++ b/l3build.ins
@@ -1,6 +1,6 @@
 \iffalse meta-comment
 
-File l3build.ins Copyright (C) 2014-2018,2021,2023 The LaTeX Project
+File l3build.ins Copyright (C) 2014-2023 The LaTeX Project
 
 It may be distributed and/or modified under the conditions of the
 LaTeX Project Public License (LPPL), either version 1.3c of this
@@ -32,7 +32,7 @@ license information is placed in the derived files.
 
 \preamble
 
-Copyright (C) 2014-2021,2023 The LaTeX Project
+Copyright (C) 2014-2023 The LaTeX Project
 
 It may be distributed and/or modified under the conditions of
 the LaTeX Project Public License (LPPL), either version 1.3c of

--- a/l3build.lua
+++ b/l3build.lua
@@ -2,7 +2,7 @@
 
 --[[
 
-File l3build.lua Copyright (C) 2014-2022 The LaTeX Project
+File l3build.lua Copyright (C) 2014-2023 The LaTeX Project
 
 It may be distributed and/or modified under the conditions of the
 LaTeX Project Public License (LPPL), either version 1.3c of this


### PR DESCRIPTION
Currently this PR give "Yes" and <s>"Yes"</s>"No" (see https://github.com/latex3/l3build/issues/325#issuecomment-1856592871) to the questions I asked in #325.

> Questions:
> 
> * Is it ok to add 2023 to copyright notices to _all_ `l3build*.lua` files even if some of them are not updated in 2023?
> * Does `l3build` want to keep precise copyright year lists, like
>   https://github.com/latex3/l3build/blob/1cae1aa62f94be10c99ffbddfa9851300ec0581d/l3build-help.lua#L3

Closes #325