### PR TITLE
Throw warnings on unknown doc name(s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Changed
+- Throw warnings on unknown doc name(s)
+
 ## [2023-12-15]
 
 ### Fixed

--- a/l3build-typesetting.lua
+++ b/l3build-typesetting.lua
@@ -184,6 +184,12 @@ function doc(files)
   local errorlevel = docinit()
   if errorlevel ~= 0 then return errorlevel end
   local done = {}
+  local files_unknown = {}
+  if files and next(files) then
+    for _, file in pairs(files) do
+      files_unknown[file] = true
+    end
+  end
   for _,typesetfiles in ipairs({typesetdemofiles,typesetfiles}) do
     for _,glob in pairs(typesetfiles) do
       local destpath,globstub = splitpath(glob)
@@ -198,6 +204,7 @@ function doc(files)
             typeset = false
             for _,file in pairs(files) do
               if name == file then
+                files_unknown[file] = nil
                 typeset = true
                 break
               end
@@ -218,6 +225,12 @@ function doc(files)
         end
       end
     end
+  end
+  if next(files_unknown) then
+    for file, _ in pairs(files_unknown) do
+      print("Unknown doc name \"" .. file .. "\"")
+    end
+    return 1
   end
   return 0
 end


### PR DESCRIPTION
Running `texlua ./build.lua doc xxx yyy zzz`,
- before
  ```
  This is pdfTeX, ...
  ...
  Transcript written on l3build.log.
  ```
- after
  ```
  This is pdfTeX, ...
  ...
  Transcript written on l3build.log.
  Unknown doc name "xxx"
  Unknown doc name "zzz"
  Unknown doc name "yyy"
  ```

