### PR TITLE
Add missing `gsub` local binding

### DIFF
--- a/l3build-aux.lua
+++ b/l3build-aux.lua
@@ -25,6 +25,7 @@ for those people who are interested.
 -- local safety guards and shortcuts
 
 local match = string.match
+local gsub  = string.gsub
 
 local pairs = pairs
 local print = print


### PR DESCRIPTION
Needed after commit 6a9f282 (Move runcmd() to l3build-aux, 2023-07-17).

`gsub` is used by `runcmd()` defined in `l3build-aux.lua`, on line 200
https://github.com/latex3/l3build/blob/5ec29167b82f73966106b70acf482796de4c6c09/l3build-aux.lua#L199-L201