### PR TITLE
Get numeric error-level from `os.execute`

### DIFF
--- a/build.lua
+++ b/build.lua
@@ -93,7 +93,7 @@ function update_tag(file,content,tagname,tagdate)
 end
 
 function tag_hook(tagname)
-  os.execute('git commit -a -m "Step release tag"')
+  return select(3, os.execute('git commit -a -m "Step release tag"'))
 end
 
 if not release_date then

--- a/l3build-check.lua
+++ b/l3build-check.lua
@@ -695,7 +695,7 @@ function base_compare(test_type,name,engine,cleanup)
   if compare then
     return compare(difffile, reffile, genfile, cleanup, name, engine)
   end
-  local errorlevel = execute(os_diffexe .. " "
+  local errorlevel = execute_with_errorlevel(os_diffexe .. " "
     .. normalize_path(reffile .. " " .. genfile .. " > " .. difffile))
   if errorlevel == 0 or cleanup then
     remove(difffile)
@@ -722,14 +722,14 @@ function compare_tlg(difffile, tlgfile, logfile, cleanup, name, engine)
     local luatlgfile = testdir .. "/" .. testname .. tlgext
     rewrite(tlgfile,luatlgfile,normalize_lua_log)
     rewrite(logfile,lualogfile,normalize_lua_log,true)
-    errorlevel = execute(os_diffexe .. " "
+    errorlevel = execute_with_errorlevel(os_diffexe .. " "
       .. normalize_path(luatlgfile .. " " .. lualogfile .. " > " .. difffile))
     if cleanup then
       remove(lualogfile)
       remove(luatlgfile)
     end
   else
-    errorlevel = execute(os_diffexe .. " "
+    errorlevel = execute_with_errorlevel(os_diffexe .. " "
       .. normalize_path(tlgfile .. " " .. logfile .. " > " .. difffile))
   end
   if errorlevel == 0 or cleanup then

--- a/l3build-file-functions.lua
+++ b/l3build-file-functions.lua
@@ -225,6 +225,10 @@ function fileexists(file)
   end
 end
 
+function execute_with_errorlevel(command)
+  return select(3, execute(command))
+end
+
 -- Copy files 'quietly'
 function cp(glob, source, dest)
   local errorlevel
@@ -233,12 +237,12 @@ function cp(glob, source, dest)
     -- p_cwd is the counterpart relative to the current working directory
     if os_type == "windows" then
       if direxists(p.cwd) then
-        errorlevel = execute(
+        errorlevel = execute_with_errorlevel(
           'xcopy /y /e /i "' .. unix_to_win(p.cwd) .. '" '
              .. unix_to_win(dest .. '/' .. escapepath(p.src)) .. ' > nul'
         ) and 0 or 1
       else
-        errorlevel = execute(
+        errorlevel = execute_with_errorlevel(
           'xcopy /y "' .. unix_to_win(p.cwd) .. '" '
              .. unix_to_win(dest .. '/') .. ' > nul'
         ) and 0 or 1
@@ -249,7 +253,7 @@ function cp(glob, source, dest)
         errorlevel = mkdir(dirname(dest))
         if errorlevel ~=0 then return errorlevel end
       end
-      errorlevel = execute(
+      errorlevel = execute_with_errorlevel(
         "cp -RLf '" .. p.cwd .. "' " .. dest
       ) and 0 or 1
     end
@@ -377,11 +381,11 @@ function mkdir(dir)
     -- Windows (with the extensions) will automatically make directory trees
     -- but issues a warning if the dir already exists: avoid by including a test
     dir = unix_to_win(dir)
-    return execute(
+    return execute_with_errorlevel(
       "if not exist "  .. dir .. "\\nul " .. "mkdir " .. dir
     )
   else
-    return execute("mkdir -p " .. dir)
+    return execute_with_errorlevel("mkdir -p " .. dir)
   end
 end
 
@@ -391,9 +395,9 @@ function ren(dir, source, dest)
   if os_type == "windows" then
     source = gsub(source, "^%.+/", "")
     dest = gsub(dest, "^%.+/", "")
-    return execute("ren " .. unix_to_win(dir) .. source .. " " .. dest)
+    return execute_with_errorlevel("ren " .. unix_to_win(dir) .. source .. " " .. dest)
   else
-    return execute("mv " .. dir .. source .. " " .. dir .. dest)
+    return execute_with_errorlevel("mv " .. dir .. source .. " " .. dir .. dest)
   end
 end
 
@@ -418,15 +422,15 @@ function rmdir(dir)
   -- First, make sure it exists to avoid any errors
   mkdir(dir)
   if os_type == "windows" then
-    return execute("rmdir /s /q " .. unix_to_win(dir))
+    return execute_with_errorlevel("rmdir /s /q " .. unix_to_win(dir))
   else
-    return execute("rm -r " .. dir)
+    return execute_with_errorlevel("rm -r " .. dir)
   end
 end
 
 -- Run a command in a given directory
 function run(dir, cmd)
-  return execute("cd " .. dir .. os_concat .. cmd)
+  return execute_with_errorlevel("cd " .. dir .. os_concat .. cmd)
 end
 
 -- Split a path into file and directory component


### PR DESCRIPTION
This PR makes sure `l3build` gets an numeric error-level from `os.execute()`.

**Background**

Till Lua 5.1.x, `os.execute()` returns only one result which represents status code.

Starting from Lua 5.2, `os.execute()` returns 3 results, among which the first result is either `true` or `nil`, thus it can no longer be used as numeric `errorlevel` in l3build.

See Lua 5.2 Reference Manual, [8.2 – Changes in the Libraries](https://www.lua.org/manual/5.2/manual.html#8.2)

> Function `os.execute` now returns `true` when command terminates successfully and `nil` plus error information otherwise.

Full doc of [`os.execute()`](https://www.lua.org/manual/5.3/manual.html#pdf-os.execute) in Lua 5.3, the Lua version that latest LuaTeX (hence `texlua`) uses.

> `os.execute ([command])`
> This function is equivalent to the ISO C function system. It passes command to be executed by an operating system shell. Its first result is `true` if the command terminated successfully, or `nil` otherwise. After this first result the function returns a string plus a number, as follows:
>
> - "`exit`": the command terminated normally; the following number is the exit status of the command.
> - "`signal`": the command was terminated by a signal; the following number is the signal that terminated the command.
When called without a command, os.execute returns a boolean that is true if a shell is available.