### PR TITLE
Reindent codes

### DIFF
--- a/l3build-arguments.lua
+++ b/l3build-arguments.lua
@@ -248,14 +248,14 @@ local function argparse()
             return { target = "help" }
           end
         else
-         if not optarg then
-          optarg = arg[i + 1]
           if not optarg then
-            stderr:write("Missing value for option " .. a .."\n")
-            return { target = "help" }
+            optarg = arg[i + 1]
+            if not optarg then
+              stderr:write("Missing value for option " .. a .."\n")
+              return { target = "help" }
+            end
+            i = i + 1
           end
-          i = i + 1
-         end
         end
       else
         stderr:write("Unknown option " .. a .."\n")
@@ -283,7 +283,7 @@ local function argparse()
     end
   end
   if next(names) then
-   result["names"] = names
+    result["names"] = names
   end
   return result
 end

--- a/l3build-check.lua
+++ b/l3build-check.lua
@@ -628,10 +628,10 @@ function runcheck(name, hide)
     end
   end
   for i=1, #failedengines do
-     if failedengines[i] == stdengine then
-        failedengines = {stdengine}
-        break
-     end
+    if failedengines[i] == stdengine then
+      failedengines = {stdengine}
+      break
+    end
   end
   -- Return everything
   return errorlevel, failedengines
@@ -657,7 +657,7 @@ function setup_check(name, engine)
     end
   end
   if found then
-     return
+    return
   end
   -- Attempt to generate missing reference file from expectation
   for _, kind in ipairs(test_order) do
@@ -674,7 +674,7 @@ function setup_check(name, engine)
     end
   end
   if found then
-     return
+    return
   end
   print(
     "Error: failed to find any reference or expectation file for "
@@ -922,9 +922,9 @@ local function showsavecommands(failurelist)
   end
   f:write"\n"
   if savecmds[stdengine] then
-     print("\n  Afterwards test for engine specific changes using\n")
-     print("    " .. checkcmd)
-     f:write(checkcmd)
+    print("\n  Afterwards test for engine specific changes using\n")
+    print("    " .. checkcmd)
+    f:write(checkcmd)
   end
   f:close()
   print("")

--- a/l3build-manifest.lua
+++ b/l3build-manifest.lua
@@ -128,7 +128,7 @@ manifest_build_init = function(entry)
     Nchar_descr   = 11 , -- TODO: generalise
   }
 
-   -- copy default options to each group if necessary
+  -- copy default options to each group if necessary
   for kk,ll in pairs(manifest_group_defaults) do
     if entry[kk] == nil then
       entry[kk] = ll

--- a/l3build-stdmain.lua
+++ b/l3build-stdmain.lua
@@ -122,12 +122,12 @@ target_list =
         desc = "Updates release tags in files",
         func = tag,
         pre  = function(names)
-           if names and #names > 1 then
-             print("Too many tags specified; exactly one required")
-             exit(1)
-           end
-           return 0
-         end
+            if names and #names > 1 then
+              print("Too many tags specified; exactly one required")
+              exit(1)
+            end
+            return 0
+          end
       },
     uninstall =
       {
@@ -171,10 +171,10 @@ function main(target,names)
     end
   else
     if target_list[target].pre then
-     errorlevel = target_list[target].pre(names)
-     if errorlevel ~= 0 then
-       exit(1)
-     end
+      errorlevel = target_list[target].pre(names)
+      if errorlevel ~= 0 then
+        exit(1)
+      end
     end
     errorlevel = target_list[target].func(names)
   end

--- a/l3build-typesetting.lua
+++ b/l3build-typesetting.lua
@@ -63,7 +63,7 @@ function bibtex(name,dir)
     if os_type == "windows" then
       grep = "\\\\"
     else
-     grep = "\\\\\\\\"
+      grep = "\\\\\\\\"
     end
     if run(dir,
         os_grepexe .. " \"^" .. grep .. "citation{\" " .. name .. ".aux > "

--- a/l3build-upload.lua
+++ b/l3build-upload.lua
@@ -129,8 +129,8 @@ function upload(tagnames)
     print("Are you sure you want to continue? [y/n]" )
     io.stdout:write("> "):flush()
     if lower(read(),1,1) ~= "y" then
-       print'Aborting'
-       return 1
+      print'Aborting'
+      return 1
     end
   end
 
@@ -245,9 +245,9 @@ function shell(s)
   local t = assert(h:read('*a'))
   local success = h:close()
   if (success) then
-   return t
+    return t
   else
-   error("\nError from shell command:\n" .. s .. "\n" .. t .. "\n")
+    error("\nError from shell command:\n" .. s .. "\n" .. t .. "\n")
   end
 end
 
@@ -356,7 +356,7 @@ function input_multi_line_field (name)
       if answer_line~=nil then
         field = field .. "\n" .. answer_line
       end
-     end
+    end
   until (return_count==3 or answer_line==nil or answer_line=='\004')
   return field
 end

--- a/l3build.lua
+++ b/l3build.lua
@@ -177,11 +177,11 @@ if #checkconfigs > 1 then
             exit(2)
           end
           for line in f:lines() do
-             if line == "" then break end
-             savecmds = savecmds .. "  " .. line .. "\n"
+            if line == "" then break end
+            savecmds = savecmds .. "  " .. line .. "\n"
           end
           for line in f:lines() do
-             recheckcmds = recheckcmds .. "  " .. line .. "\n"
+            recheckcmds = recheckcmds .. "  " .. line .. "\n"
           end
           f:close()
         end


### PR DESCRIPTION
All lines in sub-table of `groups` in `manifest_setup()` in `l3build-manifest-setup.lua` use three-space indentations (for example lines 60-61 in snippet below) and they are intact since I think that would change too many stable code lines.

https://github.com/latex3/l3build/blob/a4fc2f98a898c369f8cd2c7bc07fb8798adf00fc/l3build-manifest-setup.lua#L57-L61