### PR TITLE
Update weblinks to https, remaining part

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,5 +32,5 @@ The LaTeX kernel is developed by [The LaTeX Project](https://latex-project.org).
 -----
 
 <p>Copyright (C) 2014-2023 The LaTeX Project <br />
-<a href="http://latex-project.org/">http://latex-project.org/</a> <br />
+<a href="https://latex-project.org/">https://latex-project.org/</a> <br />
 All rights reserved.</p>

--- a/examples/Bundle-Flat/README.md
+++ b/examples/Bundle-Flat/README.md
@@ -11,5 +11,5 @@ in the build script for each module.
 -----
 
 Copyright (C) 2014-2023 The LaTeX Project <br />
-<http://latex-project.org/> <br />
+<https://latex-project.org/> <br />
 All rights reserved.

--- a/examples/Bundle-Tree/README.md
+++ b/examples/Bundle-Tree/README.md
@@ -11,5 +11,5 @@ in the build script for each module.
 -----
 
 Copyright (C) 2014-2023 The LaTeX Project <br />
-<http://latex-project.org/> <br />
+<https://latex-project.org/> <br />
 All rights reserved.

--- a/examples/README.md
+++ b/examples/README.md
@@ -20,5 +20,5 @@ The examples are:
 -----
 
 Copyright (C) 2014-2023 The LaTeX Project <br />
-<http://latex-project.org/> <br />
+<https://latex-project.org/> <br />
 All rights reserved.

--- a/examples/Simple-Flat/README.md
+++ b/examples/Simple-Flat/README.md
@@ -12,5 +12,5 @@ As the `.dtx` package file grows larger, it may be sensible to split it up into 
 -----
 
 Copyright (C) 2014-2023 The LaTeX Project <br />
-<http://latex-project.org/> <br />
+<https://latex-project.org/> <br />
 All rights reserved.

--- a/examples/Simple-Tree/README.md
+++ b/examples/Simple-Tree/README.md
@@ -11,5 +11,5 @@ This is left as an exercise to the energetic package writer studying these examp
 -----
 
 Copyright (C) 2014-2023 The LaTeX Project <br />
-<http://latex-project.org/> <br />
+<https://latex-project.org/> <br />
 All rights reserved.

--- a/l3build.dtx
+++ b/l3build.dtx
@@ -340,7 +340,7 @@
 % process.
 %
 %The example scripts given in Section~\vref{sec:examples} largely cover the required knowledge in Lua programing.
-% For a more advanced usage, one may consult general Lua documentations including \url{http://www.lua.org/manual/5.3/manual.html} and for the few |texlua| specific additions see section 4.2 of the \LuaTeX{} manual available locally with |texdoc luatex| command line or at \url{https://www.pragma-ade.com/general/manuals/luatex.pdf}.
+% For a more advanced usage, one may consult general Lua documentations including \url{https://www.lua.org/manual/5.3/manual.html} and for the few |texlua| specific additions see section 4.2 of the \LuaTeX{} manual available locally with |texdoc luatex| command line or at \url{https://www.pragma-ade.com/general/manuals/luatex.pdf}.
 %
 % \subsection{Main build targets}
 %


### PR DESCRIPTION
Continuation of d6079bf (Update weblinks to https, 2023-12-15).

Now `rg --no-heading -F 'http:'` returns zero matches.