### PR TITLE
Fix type of return value of `runtest_tasks()` in doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Fixed
+- Type of return value of `runtest_tasks()` in doc
+
 ## [2024-01-04]
 
 ### Changed

--- a/l3build.dtx
+++ b/l3build.dtx
@@ -1157,7 +1157,8 @@
 % of the current test (this is equivalent to \TeX{}'s \cs{jobname},
 % \emph{i.e.}~it lacks an extension) and the current run number.
 % The function |runtest_tasks| is run after the main call to the
-% engine for a test cycle. It should return an errorlevel value.
+% engine for a test cycle. It should return a string consists of task(s),
+% i.e., the CLI command(s) to execute.
 % If more than one task is required, these should be separated
 % by use of |os_concat|, a string variable defined by \pkg{l3build} as the
 % correct concatenation marker for the system. An example of |runtest_tasks|


### PR DESCRIPTION
It actually returns a string, not a number representing errorlevel.

Found when reviewing 2371f4c (Always execute "runtest_tasks()" (closes #<span></span>327), 2024-01-04).