### PR TITLE
Typo, missing space after semicolon

### DIFF
--- a/l3build.dtx
+++ b/l3build.dtx
@@ -592,7 +592,7 @@
 %
 % \begin{buildcmd}{tag [\meta{tag name}]}
 % Applies the Lua |update_tag()| function to modify the contents of all the files
-% specified by |tagfiles|;this function updates the `release tag' (or package version)
+% specified by |tagfiles|; this function updates the `release tag' (or package version)
 % and date.
 % The tag is given as the optional command line argument \meta{tag name} and the date using
 % |--date| (or |-d|). If not given, the date will default to the current date in


### PR DESCRIPTION
Introduced in 0231d16 (Update from Chris, 2024-01-11) and pointed out by Chris in https://github.com/latex3/l3build/pull/340#issuecomment-1887384493.