### PR TITLE
Drop switch --force|-f

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ this project uses date-based 'snapshot' version identifiers.
 ### Added
 - Switch `-s|--stdengine` to run a set of tests only with the standard engine
   even where this varies between configs (issue \#343)
+
+### Removed
+- Switch `--force|-f`
+
 ## [2024-01-09]
 
 ### Fixed

--- a/l3build-arguments.lua
+++ b/l3build-arguments.lua
@@ -307,4 +307,5 @@ function check_engines(config)
       end
     end
   end
+  if not next(checkengines) then exit(0) end
 end

--- a/l3build-arguments.lua
+++ b/l3build-arguments.lua
@@ -89,12 +89,6 @@ option_list =
         desc  = "Name of first test to run",
         type  = "string"
       },
-    force =
-      {
-        desc  = "Forces tests to run, even if engine is not set up",
-        short = "f",
-        type  = "boolean"
-      },
     full =
       {
         desc = "Installs all files",
@@ -298,21 +292,18 @@ options = argparse()
 
 -- Sanity check
 function check_engines(config)
-  if options["engine"] and not options["force"] then
+  if options["engine"] then
     -- Make a lookup table
     local t = { }
     for _, engine in pairs(checkengines) do
       t[engine] = true
     end
-    for _, engine in pairs(options["engine"]) do
-      if not t[engine] then
-        print("\n! Error: Engine \"" .. engine .. "\" not set up for testing with configuration \"" .. config .. "\"!")
-        print("\n  Valid values are:")
-        for _, engine in ipairs(checkengines) do
-          print("  - " .. engine)
-        end
-        print("")
-        exit(1)
+    checkengines = {}
+    for _,engine in ipairs(options["engine"]) do
+      if t[engine] then
+          insert(checkengines,engine)
+      else
+        print("Skipping unknown engine " .. engine)
       end
     end
   end

--- a/l3build-check.lua
+++ b/l3build-check.lua
@@ -597,8 +597,6 @@ function runcheck(name, hide)
   local checkengines = checkengines
   if options["stdengine"] then
     checkengines = {stdengine}
-  elseif options["engine"] then
-    checkengines = options["engine"]
   end
   local failedengines = {}
   -- Used for both .lvt and .pvt tests

--- a/l3build.1
+++ b/l3build.1
@@ -55,8 +55,6 @@ Sets the epoch for tests and typesetting
 Takes the upload announcement from the given file
 .IP --first
 Name of first test to run
-.IP --force|-f
-Force tests to run if engine is not set up
 .IP --full
 Installs all files
 .IP --halt-on-error|-H

--- a/l3build.dtx
+++ b/l3build.dtx
@@ -379,9 +379,6 @@
 % \item |--epoch| Sets the epoch for typesetting and testing
 % \item |--file| (|-F|) Takes the upload announcement from the given file
 % \item |--first| Name of the first test to run
-% \item |--force| (|-f|) Forces checks to run even if sanity
-%   checks fail, \emph{e.g.}~when |--engine| is not given in
-%   \var{checkengines}
 % \item |--full| Instructs the \texttt{install} target to include the
 %   \texttt{doc} and \texttt{source} trees
 % \item |--halt-on-error| (|-H|) Specifies that checks
@@ -1676,7 +1673,6 @@
 %       \var{epoch}         & String  \\
 %       \var{file}          & string  \\
 %       \var{first}         & Boolean \\
-%       \var{force}         & Boolean \\
 %       \var{full}          & Boolean \\
 %       \var{halt-on-error} & Boolean \\
 %       \var{help}          & Boolean \\


### PR DESCRIPTION
Unknown engines are then skipped with a message, rather than leading to an error.