### PR TITLE
Skip unknown engine(s) when saving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Fixed
+- Skip unknown engines correctly in `l3build save`
+
 ## [2024-02-08]
 
 ### Changed

--- a/l3build-check.lua
+++ b/l3build-check.lua
@@ -1119,7 +1119,12 @@ function save(names)
       return errorlevel
     end
   end
-  local engines = options["engine"] or {stdengine}
+  local engines
+  if options["engine"] then
+    engines = checkengines -- sanitized by check_engines()
+  else
+    engines = {stdengine}
+  end
   if names == nil then
     print("Arguments are required for the save command")
     return 1


### PR DESCRIPTION
This PR solves a `l3build save` problem that unknown engines passed to `-e|--engine` are not skipped.

Run `texlua ./l3build.lua save -epdftex,XXX 00-test-1` in this repository,
- Before

  Although `Skipping unknown engine XXX` is printed, unknown engine `XXX` is not skipped hence the problem `sh: XXX: command not found`.
  ```
  $ texlua ./l3build.lua save -epdftex,XXX 00-test-1
  Skipping unknown engine XXX
  This is pdfTeX, ...
  ...
  Transcript written on 00-test-1.log.
  Creating and copying 00-test-1.XXX.tlg
  sh: XXX: command not found
  ./l3build-check.lua:97: ./build/test/00-test-1.log: No such file or directory
  ```

- After, unknown engine is correctly skipped.
  ```
  $ texlua ./l3build.lua save -epdftex,XXX 00-test-1
  Skipping unknown engine XXX
  This is pdfTeX, ...
  ...
  Transcript written on 00-test-1.log.
  ```