### PR TITLE
No more 0 and 0 or 1

### DIFF
--- a/l3build-file-functions.lua
+++ b/l3build-file-functions.lua
@@ -236,12 +236,12 @@ function cp(glob, source, dest)
         errorlevel = execute(
           'xcopy /y /e /i "' .. unix_to_win(p.cwd) .. '" '
              .. unix_to_win(dest .. '/' .. escapepath(p.src)) .. ' > nul'
-        ) and 0 or 1
+        ) -- execute returns an integer
       else
         errorlevel = execute(
           'xcopy /y "' .. unix_to_win(p.cwd) .. '" '
              .. unix_to_win(dest .. '/') .. ' > nul'
-        ) and 0 or 1
+        ) -- execute returns an integer
       end
     else
       -- Ensure we get similar behavior on all platforms
@@ -251,7 +251,7 @@ function cp(glob, source, dest)
       end
       errorlevel = execute(
         "cp -RLf '" .. p.cwd .. "' " .. dest
-      ) and 0 or 1
+      ) -- execute returns an integer
     end
     if errorlevel ~=0 then
       return errorlevel


### PR DESCRIPTION
l3build-core.lua defines execute51 and a local require

The old `build_require` function made little sense, so it has been removed.

The implementation of `os.execute` in `texlua` is not that of Lua 5.3. It is still at version 5.1. See [https://tug.org/pipermail/luatex/2015-November/005536.htm](https://tug.org/pipermail/luatex/2015-November/005536.html).

Moreover, `os.execute` version 5.3 is buggy on windows in certain situations. This has been fixed in Lua 5.4. If texlua ever switches to Lua 5.4, we just have to redefine execute51 et voilà.
 
Instead of adding more global variables, the `l3build-setup` module returns a table with appropriate fields. 
This table is globally available with `require("l3build")`. Actually, this is for development only, which means that the `build.lua` and various `config-....lua` are not expected to use this.
