### PR TITLE
Update l3build-arguments.lua

### DIFF
--- a/l3build-arguments.lua
+++ b/l3build-arguments.lua
@@ -45,6 +45,7 @@ option_list =
     date =
       {
         desc  = "Sets the date to insert into sources",
+        short = "d",
         type  = "string"
       },
     debug =


### PR DESCRIPTION
`l3build.dtx` refers to a short `-d` for `--date` at line [597](https://github.com/latex3/l3build/blob/5db0d64ba5647741114e3f0a7002a85fd1775bdd/l3build.dtx#L597) but it does not exist.