### PR TITLE
UTC date in zip archive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ this project uses date-based 'snapshot' version identifiers.
 
 ### Fixed
 - Global `typesetopts` no longer ignored for `luatex` and `lualatex` (issue \#351)
+- 'UT' timestamps in zip archives are now in UTC
 
 ## [2024-05-27]
 

--- a/build.lua
+++ b/build.lua
@@ -50,7 +50,7 @@ function update_tag(file,content,tagname,tagdate)
   local iso = "%d%d%d%d%-%d%d%-%d%d"
   local url = "https://github.com/latex3/l3build/compare/"
   -- update copyright
-  local year = os.date("%Y")
+  local year = os.date("%Y") -- in local TZ
   local oldyear = math.tointeger(year - 1)
   if string.match(content,"%(C%)%s*" .. oldyear .. " The LaTeX Project") then
     content = string.gsub(content,

--- a/l3build-tagging.lua
+++ b/l3build-tagging.lua
@@ -62,7 +62,7 @@ local function update_file_tag(file,tagname,tagdate)
 end
 
 function tag(tagnames)
-  local tagdate = options["date"] or os_date("%Y-%m-%d")
+  local tagdate = options["date"] or os_date("%Y-%m-%d") -- in local TZ
   local tagname = nil
   if tagnames then
     tagname = tagnames[1]

--- a/l3build-zip.lua
+++ b/l3build-zip.lua
@@ -22,18 +22,19 @@ for those people who are interested.
 
 --]]
 
-local concat = table.concat
-local open = io.open
-local osdate = os.date
-local pack = string.pack
+local concat  = table.concat
+local open    = io.open
+local os_date = os.date
+local os_time = os.time
+local pack    = string.pack
 local setmetatable = setmetatable
-local iotype = io.type
+local iotype  = io.type
 
 local compress = zlib.compress
 local crc32 = zlib.crc32
 
 local function encode_time(unix)
-  local t = osdate('*t', unix)
+  local t = os_date('!*t', unix)
   local date = t.day | (t.month << 5) | ((t.year-1980) << 9)
   local time = (t.sec//2) | (t.min << 5) | (t.hour << 11)
   return date, time
@@ -75,7 +76,7 @@ local meta = {__index = {
     if #compressed >= #content then
       compressed = nil
     end
-    local timestamp = os.time()
+    local timestamp = os_time()
     local date, time = encode_time(timestamp)
     local central_extra, local_extra = extra_timestamp(timestamp, nil, nil)
     z.f:write(pack("<c4I2I2I2I2I2I4I4I4I2I2",

--- a/l3build.dtx
+++ b/l3build.dtx
@@ -594,7 +594,7 @@
 % specified by |tagfiles|; this function updates the `release tag' (or package version)
 % and date.
 % The tag is given as the optional command line argument \meta{tag name} and the date using
-% |--date| (or |-d|). If not given, the date will default to the current date in
+% |--date| (or |-d|). If not given, the date will default to the current local date in
 % ISO format (YYYY-MM-DD). If no \meta{tag name} is given, the tag will default to |nil|.
 % Both are passed as arguments to the |update_tag()| function.
 %


### PR DESCRIPTION
avoid local date in tagging.
It assumes that the `os.date` is not buggy.
Fix a bug in l3build-zip