### PR TITLE
avoid nroff errors in text extracted from README

### DIFF
--- a/build.lua
+++ b/build.lua
@@ -117,7 +117,7 @@ function  docinit_hook()
   local _,desc_start = find(readme,"Overview\n--------")
   local desc_end,_ = find(readme,"Issues")
 
-  local overview = readme:sub(desc_start + 2,desc_end - 2):gsub("[`_]","")
+  local overview = readme:sub(desc_start + 8,desc_end - 2):gsub("[_]",""):gsub("`",'"'):gsub("[*] ","\n * ")
   insert(man_t,overview)
 
   local cmd = "texlua ./" .. module .. ".lua --help"


### PR DESCRIPTION
The first part of the man page is extracted from README.md and has three errors

A `-----` mardown header line gets left in

`.tex` gets left at the start of a line and interpreted as an invalid nroff command so vanishes

The bullet list is lost with bullets appearing inline

The new version isn't technically an nroff list but I think it's fine.

Old

![image](https://github.com/latex3/l3build/assets/1268738/d23e5c90-5bf0-46c4-84f2-431c4a3b4e37)


New

![image](https://github.com/latex3/l3build/assets/1268738/53a0a73f-d12f-4c69-934e-6a96df01056c)




