### PR TITLE
Doc: Type -> Lua type

### DIFF
--- a/l3build.dtx
+++ b/l3build.dtx
@@ -1667,27 +1667,28 @@
 %   \begin{center}
 %   \begin{tabular}{ll}
 %     \toprule
-%     Entry & Type \\
+%     Entry & Lua type \\
 %     \midrule
-%       \var{config}        & Table   \\
-%       \var{date}          & String  \\
-%       \var{dirty}         & Boolean \\
-%       \var{dry-run}       & Boolean \\
-%       \var{email}         & String  \\
-%       \var{engine}        & Table   \\
-%       \var{epoch}         & String  \\
-%       \var{file}          & string  \\
-%       \var{first}         & Boolean \\
-%       \var{full}          & Boolean \\
-%       \var{halt-on-error} & Boolean \\
-%       \var{help}          & Boolean \\
-%       \var{message}       & string  \\
-%       \var{names}         & Table   \\
-%       \var{quiet}         & Boolean \\
-%       \var{rerun}         & Boolean \\
-%       \var{shuffle}       & Boolean \\
-%       \var{stdengine}     & Boolean \\
-%       \var{texmfhome}     & String  \\
+%       \var{config}        & |table|   \\
+%       \var{date}          & |string|  \\
+%       \var{dirty}         & |boolean| \\
+%       \var{dry-run}       & |boolean| \\
+%       \var{email}         & |string|  \\
+%       \var{engine}        & |table|   \\
+%       \var{epoch}         & |string|  \\
+%       \var{file}          & |string|  \\
+%       \var{first}         & |boolean| \\
+%       \var{full}          & |boolean| \\
+%       \var{halt-on-error} & |boolean| \\
+%       \var{help}          & |boolean| \\
+%       \var{message}       & |string|  \\
+%       \var{names}         & |table|   \\
+%       \var{quiet}         & |boolean| \\
+%       \var{rerun}         & |boolean| \\
+%       \var{shuffle}       & |boolean| \\
+%       \var{stdengine}     & |boolean| \\
+%       \var{target}        & |string|  \\
+%       \var{texmfhome}     & |string|  \\
 %     \bottomrule
 %     \end{tabular}
 %   \end{center}

--- a/l3build.dtx
+++ b/l3build.dtx
@@ -1662,8 +1662,10 @@
 %
 % \begin{variable}{options}
 %   The |options| table holds the values passed to \pkg{l3build} at the
-%   command line. The possible entries in the table are given in the table
-%   below.
+%   command line. Each possible \meta{entry} given below corresponds to
+%   |--|\meta{entry} given at the command line, except the |target| entry
+%   which is self explanatory and the |names| entry which corresponds to \meta{name(s)}
+%   for |check|, |doc|, |save| and |tag| targets.  
 %   \begin{center}
 %   \begin{tabular}{ll}
 %     \toprule


### PR DESCRIPTION
Description of the `options` table:

1. some types were not capitalized
2. all types are now Lua types, conform to section 5.6
3. |target| is exposed
