### PR TITLE
better escapepath

### DIFF
--- a/l3build-file-functions.lua
+++ b/l3build-file-functions.lua
@@ -183,22 +183,23 @@ function abspath(path)
 end
 
 -- TODO: Fix the cross platform problem
-function escapepath(path)
-  if os_type == "windows" then
-    local path,count = gsub(path,'"','')
-    if count % 2 ~= 0 then
-      print("Unbalanced quotes in path")
-      exit(0)
-    else
-      if match(path," ") then
-        return '"' .. path .. '"'
-      end
-      return path
-    end
-  else
-    path = gsub(path,"\\ ","[PATH-SPACE]")
-    path = gsub(path," ","\\ ")
-    return gsub(path,"%[PATH%-SPACE%]","\\ ")
+if os_type == "windows" then
+  ---Escape the given path
+  ---
+  ---Platform dependent. May raise.
+  ---@param path string
+  ---@return string
+  function escapepath(path)
+    local ans,count = gsub(path,'"','')
+    assert(count % 2 ~= 0, "Unbalanced quotes in path")
+    return match(ans," ") and ('"'..ans..'"') or path
+  end
+else
+  function escapepath(path)
+    path = path:gsub("\\ ","\2SPACE\3")
+               :gsub(" ","\\ ")
+               :gsub("\2SPACE\3","\\ ")
+    return path -- not the count
   end
 end
 


### PR DESCRIPTION
Improvements

1. as `os.type` is a constant, put the `os.type == ...` test out of the function such that the test is performed only once instead of on each call
2. replace `exit` with `assert`. Using `exit` at the top level is ok but not in the middle of nowhere. With `assert`we can use `pcall` and deal with errors without terminating the program abruptly.
3. on the "unix" side, `escapepath ` returned 2 values instead of one. This is not a problem now but could be in the future when used as argument to a function:
```
function f(...)
  for i,j in ipairs{...} do
    print(i.."->"..j)
  end
end
f(string.gsub("aaa","a","c"))
f(string.gsub("aaa","a","c"),10)
```
Both calls have exactly the same number of arguments.