### PR TITLE
Typo, avoid ligature in long option name

### DIFF
--- a/l3build.dtx
+++ b/l3build.dtx
@@ -388,7 +388,7 @@
 % \item |--message| (|-m|) Text for upload announcement
 % \item |--quiet| (|-q|) Suppresses output from unpacking
 % \item |--rerun| Runs tests without unpacking/set up
-% \item |--show-log-on-error| To be used in addition to \texttt{--halt-on-error} and results
+% \item |--show-log-on-error| To be used in addition to |--halt-on-error| and results
 %   in the full \texttt{.log} file of a failed test to be shown on the console
 % \item |--show-saves| (|-S|) When tests fail, prints the \texttt{l3build save} commands needed
 %   to regenerate the tests assuming that the failures were false negatives.


### PR DESCRIPTION
Somehow `lmodern` package enables the "--" (double-hyphen) to en-dash ligature for `\ttfamily`, in T1 encoding. The result looks wrong for long CLI options.

No similar cases are found in `l3build.dtx`.

```tex
\documentclass{article}
\usepackage[T1]{fontenc}
\usepackage{lmodern}

\begin{document}
\verb|--option|

\texttt{--option}
\end{document}
```

![image](https://github.com/user-attachments/assets/e7ac6224-2b4b-4873-b0de-5fe3dd4ac7eb)

In `l3build.pdf`, page 4
![image](https://github.com/user-attachments/assets/79a4d097-18b2-4217-b23b-e6d273a5fabe)
