### PR TITLE
master -> main in doc

### DIFF
--- a/l3build.dtx
+++ b/l3build.dtx
@@ -677,7 +677,7 @@
 % \end{floating-listing}
 %
 % A collection of full examples (source files in various layouts) are available
-% at \url{https://github.com/latex3/l3build/tree/master/examples}.
+% at \url{https://github.com/latex3/l3build/tree/main/examples}.
 %
 % \subsection{Variables}
 %
@@ -801,7 +801,7 @@
 % files are in a sub-directory.
 %
 % A series of example layouts and matching |build.lua| files are available from
-% \url{https://github.com/latex3/l3build/tree/master/examples}.
+% \url{https://github.com/latex3/l3build/tree/main/examples}.
 %
 % For more complex layouts in which sources are laid out in TDS format and
 % should be used directly, the table \var{tdsdirs} is available. Each entry


### PR DESCRIPTION
Changes the urls in the doc to reflect the change in branch name from "master" to "main".