### PR TITLE
remove `\usepackage{expl3}` from doc examples

### DIFF
--- a/l3build.dtx
+++ b/l3build.dtx
@@ -1058,7 +1058,6 @@
 % \begin{Verbatim}[frame=single,fontsize=\small]
 % \input{regression-test.tex}
 % \documentclass{article}
-% \usepackage{expl3}
 % \START
 % \ExplSyntaxOn
 % \box_new:N \l_tmp_box
@@ -1156,7 +1155,6 @@
 % \begin{Verbatim}[frame=single,fontsize=\small]
 % \input{regression-test.tex}
 % \documentclass{article}
-% \usepackage{expl3}
 % \START
 % \showoutput
 % % Test content here


### PR DESCRIPTION
Since it's incorporated into the format I think it's better not to load the stub in the doc examples.