### PR TITLE
Correct defaults of `forcecheckepoch` and `forcedocepoch` in doc

### DIFF
--- a/l3build.dtx
+++ b/l3build.dtx
@@ -141,8 +141,8 @@
 \luavarset{indexstyle}   {"gind.ist"}{MakeIndex style for index creation}
 \luavarset{specialtypesetting}{\meta{table}} {Non-standard typesetting combinations}
 \luavarseparator
-\luavarset{forcecheckepoch}{"true"}    {Force epoch when running tests}
-\luavarset{forcedocepoch}  {"false"}   {Force epoch when typesetting}
+\luavarset{forcecheckepoch}{true}     {Force epoch when running tests}
+\luavarset{forcedocepoch}  {false}    {Force epoch when typesetting}
 \luavarseparator
 \luavarset{asciiengines}{\{"pdftex"\}}{Engines which should log as pure ASCII}
 \luavarset{checkruns}   {1}           {Number of runs to complete for a test before comparing the log}


### PR DESCRIPTION
They are boolean variables but were documented with string defaults.