### PR TITLE
Add leading dot to `diffext` values in docs

### DIFF
--- a/l3build.dtx
+++ b/l3build.dtx
@@ -411,8 +411,8 @@
 % and |diffext| can be used to adjust the choice of comparison made: the standard
 % values are
 % \begin{itemize}
-%   \item[Windows] |diffext = fc|, |diffexe = fc /n|
-%   \item[*nix] |diffext = diff|, |diffexe = diff -c --strip-trailing-cr|
+%   \item[Windows] |diffext = .fc|, |diffexe = fc /n|
+%   \item[*nix] |diffext = .diff|, |diffexe = diff -c --strip-trailing-cr|
 % \end{itemize}
 %
 % The following files are moved into the \enquote{sandbox} for the |check| process:


### PR DESCRIPTION
Leading dot is used in code but missing in docs.

https://github.com/latex3/l3build/blob/9e45675d8fea8b18e7cde268ac2733de33387f14/l3build-file-functions.lua#L133
https://github.com/latex3/l3build/blob/9e45675d8fea8b18e7cde268ac2733de33387f14/l3build-file-functions.lua#L141