### PR TITLE
Mention also underfull boxes [ci skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ this project uses date-based 'snapshot' version identifiers.
 
 ### Changed
 - Initialize all boolean config variables
-- Normalize `at lines ...` statements for overfull boxes (may require `.tlg` update)
+- Normalize `at lines ...` statements for overfull and underfull boxes
+  (may require `.tlg` update)
 
 ### Fixed
 - Skip README rename when this has no extension (issue \#388)

--- a/l3build-check.lua
+++ b/l3build-check.lua
@@ -204,7 +204,7 @@ local function normalize_log(content,engine,errlevels)
     if match(line,"^%(%w+%)%s+%d+%.$") then
       line = gsub(line,"%((%w+)%)(%s+)%d+%.", "(%1)%2....")
     end
-    -- And for overfull boxes
+    -- And for overfull and underfull boxes
     line = gsub(line, "at lines %d*%-%-%d*","at lines ...")
     -- Tidy up to ^^ notation
     for i = 0, 31 do

--- a/l3build.dtx
+++ b/l3build.dtx
@@ -883,7 +883,7 @@
 %   \item Conversion of \texttt{on line \meta{number}} to \texttt{on line ...}
 %     to allow flexibility in changes to test files.
 %   \item Conversion of \texttt{at lines \meta{number}}|--|\texttt{\meta{number}} to 
-%     \texttt{at lines ...} for overfull boxes.
+%     \texttt{at lines ...} for overfull and underfull boxes.
 %   \item Conversion of file dates to \texttt{....-..-..}, and any version
 %     numbers on the same lines to \texttt{v...}.
 %   \item Conversion of register numbers in assignment lines


### PR DESCRIPTION
A typical underfull box message looks like

    Underfull \hbox (badness 10000) in paragraph at lines 8--9
    []\OT1/cmr/m/n/10 ...

I also updated the Changelog.

Not sure whether the 2025-02-23 release is actually sent to CTAN or not. The release tag was stepped in 4678006 (Step release tag, 2025-02-23) but not Git tag was pushed.