### PR TITLE
Missed "os_concat" required on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Fixed
+- Missing `os_concat` required on Windows
+
 ## [2025-05-07]
 
 ### Added

--- a/l3build-check.lua
+++ b/l3build-check.lua
@@ -819,9 +819,10 @@ function runtest(name, engine, hide, ext, test_type, breakout)
     set_epoch_cmd(epoch, forcecheckepoch) ..
     -- Ensure lines are of a known length
     os_setenv .. " max_print_line=" .. maxprintline
-      .. os_setenv .. " error_line=" .. errorline
-      .. os_concat
-      .. os_setenv .. " half_error_line=" .. halferrorline
+      .. os_concat ..
+    os_setenv .. " error_line=" .. errorline
+      .. os_concat ..
+    os_setenv .. " half_error_line=" .. halferrorline
       .. os_concat
   for i = 1, checkruns do
     errlevels[i] = runcmd(


### PR DESCRIPTION
Originally reported in https://github.com/latex3/l3build/commit/ea8529797499f19f304326da60c021c741c15cee#r156525592.

Bash supports successive `export var1=a var2=b` but Windows cmd doesn't support `set var1=a var2=b`.
```shell
$ bash -c 'export var1=a var2=b; echo ,$var1,$var2,'
,a,b,
```