### PR TITLE
Correct a typo in Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ this project uses date-based 'snapshot' version identifiers.
 ## [Unreleased]
 
 ### Fixed
-- Support use of `\OMIT` with updated ConTeXt
+- Support use of `\TIMO` with updated ConTeXt
 
 ## [2025-07-02]
 


### PR DESCRIPTION
#423 actually fixed support for `\TIMO` with updated ConTeXt log formatting, not `\OMIT`.

The merged patch in #423 was alright, but the PR title and the commit message there were unfortunately both wrong. :(