### PR TITLE
Remove the Multi flag from repository

### DIFF
--- a/l3build.dtx
+++ b/l3build.dtx
@@ -1640,7 +1640,7 @@
 %  \texttt{development } &      & \YES & URL(s) of development channels         \\
 %  \texttt{home        } &      & \YES & URL(s) of home page                       \\
 %  \texttt{note        } &      &      & Internal note to CTAN                  \\
-%  \texttt{repository  } &      & \YES & URL(s) of source repositories          \\
+%  \texttt{repository  } &      &      & URL(s) of source repositories          \\
 %  \texttt{support     } &      & \YES & URL(s) of support channels             \\
 %  \texttt{topic       } &      & \YES & Topic(s)\footnote{See \url{https://ctan.org/topics/highscore}} \\
 %  \texttt{update      } &      &      & Boolean \texttt{true} for an update, \texttt{false} for a new package   \\


### PR DESCRIPTION
CTAN complained when I submitted an update with multiple repository values, so this commit removes the `Multi` flag from the `repository` entry in Table 2 of the l3build manual.