### PR TITLE
Update doc for `-e`, `--engine`

### DIFF
--- a/l3build.dtx
+++ b/l3build.dtx
@@ -378,7 +378,7 @@
 % \item |--dry-run| Runs the \texttt{install} target but does not copy
 %   any files: simply lists those that would be installed
 % \item |--email| Sets the email address for CTAN upload
-% \item |--engine| (|-e|) Sets the engine to use for testing
+% \item |--engine| (|-e|) Sets the engine(s) to use for testing
 % \item |--epoch| Sets the epoch for typesetting and testing
 % \item |--file| (|-F|) Takes the upload announcement from the given file
 % \item |--first| Name of the first test to run
@@ -456,8 +456,9 @@
 % \begin{buildcmd}{check \meta{name(s)}}
 % Checks only the test \texttt{\meta{name(s)}.lvt}.
 % All engines specified by \var{checkengines} are tested unless the command
-% line option |--engine| (or |-e|) has been given to limit
-% testing to a single engine. Normally testing is preceded by unpacking
+% line option |--engine| (or |-e|) has been given a comma-separated list to
+% limit testing to selected |checkengines|.
+% Normally testing is preceded by unpacking
 % source files and copying the result plus any additional support to the
 % test directory: this may be skipped using the |--rerun| (|-r|) option.
 % \end{buildcmd}
@@ -572,8 +573,13 @@
 % This command saves the output of the test to a |.tlg| file.
 % This file is then used in all subsequent checks against the \texttt{\meta{name}.lvt} test.
 %
-% If the |--engine| (or |-e|) is specified (one of |pdftex|, |xetex|, or |luatex|), the saved output is stored in \texttt{\meta{name}.\meta{engine}.tlg}. This is necessary if running the test through a different engine produces a different output.
-% A normalization process is performed when checking to avoid common differences such as register allocation; full details are listed in Section~\vref{sec:norm}.
+% If the |--engine| (or |-e|) is specified (one or more comma-separated engines
+% in |checkengines|), the saved output is stored in
+% \texttt{\meta{name}.\meta{engine}.tlg} for non-standard engines.
+% This is necessary if running the test through a different engine produces
+% a different output. A normalization process is performed when checking to
+% avoid common differences such as register allocation; full details are listed
+% in Section~\vref{sec:norm}.
 %
 % If the \var{recordstatus} variable is set \var{true}, additional information
 % will be added to the \texttt{.tlg} to record the \enquote{exit status} of the
@@ -745,9 +751,9 @@
 %
 % To allow selection of one or more configurations, and to allow saving of
 % |.tlg| files in non-standard configurations, the |--config| (|-c|) option may
-% be used. This works in the same way as |--engine|: it takes a comma list of
-% configurations to apply, overriding \var{checkconfigs}. For example, in the
-% directory containing |config-TU.lua|, you can use
+% be used. This works in the same way as |--engine|: it takes a comma-separated
+% list of configurations to apply, overriding \var{checkconfigs}. For example,
+% in the directory containing |config-TU.lua|, you can use
 % |l3build check -cconfig-TU <name(s)>| and |l3build save -cconfig-TU <name(s)>|
 % to check and save tests in |testfiles-TU| directory.
 %


### PR DESCRIPTION
It accepts one or more engines, rather than just a single one.