### PR TITLE
Skip LuaTeX-specific log normalization for `\SHOWPDFTAGS` output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Fixed
+
+- Skip LuaTeX-specific log normalization for `\SHOWPDFTAGS` output (issue \#443)
+
 ### Changed
 
 - Align `\SHOWPDFTAGS` markers (may require `.tlg` update)

--- a/l3build-check.lua
+++ b/l3build-check.lua
@@ -547,9 +547,19 @@ local function normalize_lua_log(content,luatex)
   end
   local new_content = ""
   local lastline = ""
+  local nochange = false
   local dropping = false
   for line in gmatch(content, "([^\n]*)\n") do
-    line, lastline, dropping = normalize(line, lastline, dropping)
+    -- Skip LuaTeX-specific normalization for \SHOWPDFTAGS output
+    if line == "<PDF>" then
+      nochange = true
+      lastline = ""
+    elseif line == "</PDF>" then
+      nochange = false
+    end
+    if not nochange then
+      line, lastline, dropping = normalize(line, lastline, dropping)
+    end
     if not match(line, "^ *$") then
       new_content = new_content .. line .. os_newline
     end


### PR DESCRIPTION
Fixes #443.