### PR TITLE
Revert ".tlg update"

### DIFF
--- a/testfiles-tagging/01-tagging.luatex.tlg
+++ b/testfiles-tagging/01-tagging.luatex.tlg
@@ -57,7 +57,6 @@ TEST 2: Show PDF Tags
    </Sect>
   </Document>
  </StructTreeRoot>
-
 </PDF>
 -------- 01-tagging.xml (end) -----------
 ============================================================

--- a/testfiles-tagging/01-tagging.tlg
+++ b/testfiles-tagging/01-tagging.tlg
@@ -58,7 +58,6 @@ TEST 2: Show PDF Tags
    </Sect>
   </Document>
  </StructTreeRoot>
-
 </PDF>
 -------- 01-tagging.xml (end) -----------
 ============================================================


### PR DESCRIPTION
This reverts commit f3f9c49c85f6357a5b68c639496d9557dd311362.

show-pdf-tags v1.5 removed the extra blank line before </PDF>, which was mistakenly introduced in v1.4.