### PR TITLE
Re-validate first-time CTAN upload as a new package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Fixed
+
+- Ensure first-time CTAN upload re-validates as a new package instead of
+  running the curl config as a shell script (issue \#468)
+
 ## [2026-07-10]
 
 ### Fixed

--- a/l3build-upload.lua
+++ b/l3build-upload.lua
@@ -137,21 +137,7 @@ function upload(tagnames)
     end
   end
 
-  ctan_post = construct_ctan_post(uploadfile,options["debug"])
-
-
--- curl file version
-  local curloptfile = uploadconfig.curlopt_file or (ctanzip .. ".curlopt")
-  ---@type file*?
-  local curlopt=assert(open(curloptfile,"w"))
-  ---@cast curlopt file*
-  output(curlopt)
-  write(ctan_post)
-  curlopt:close()
-  curlopt = nil
-
-  ctan_post=curlexe .. " --config " .. curloptfile
-
+  ctan_post = construct_ctan_command(uploadfile,options["debug"])
 
 if options["debug"] then
     ctan_post = ctan_post ..  ' https://httpbin.org/post'
@@ -182,7 +168,7 @@ end
     if match(fp_return,"non%-existent%spackage") then
       print("Package not found on CTAN; re-validating as new package:")
       uploadconfig.update = false
-      ctan_post = construct_ctan_post(uploadfile)
+      ctan_post = construct_ctan_command(uploadfile) ..  ' https://ctan.org/submit/'
       fp_return = shell(ctan_post .. "validate")
     end
   end
@@ -255,6 +241,19 @@ function shell(s)
   else
     error("\nError from shell command:\n" .. s .. "\n" .. t .. "\n")
   end
+end
+
+function construct_ctan_command(uploadfile,debug)
+  -- write the curl config file and return the curl command that reads it
+  local ctan_config = construct_ctan_post(uploadfile,debug)
+  local curloptfile = uploadconfig.curlopt_file or (ctanzip .. ".curlopt")
+  ---@type file*?
+  local curlopt=assert(open(curloptfile,"w"))
+  ---@cast curlopt file*
+  output(curlopt)
+  write(ctan_config)
+  curlopt:close()
+  return curlexe .. " --config " .. curloptfile
 end
 
 function construct_ctan_post(uploadfile,debug)


### PR DESCRIPTION
When you upload a package to CTAN for the first time, the first validation pass comes back saying the package does not exist yet. l3build then flips `update` to false and validates again as a new package. That second pass was broken: it called `construct_ctan_post`, which only returns the raw curl config (the `form-string="..."` lines), and handed that straight to `shell`. So instead of running curl, the shell tried to execute each config line as a command, every one failed on stderr, and because `shell` only reads stdout the whole thing looked like it succeeded. The upload reported success and sent nothing.

The initial pass got this right because it wrote the config to a file and built a real `curl --config <file> <url>` command first. This pulls that file-writing and command-assembly step out into `construct_ctan_command` and uses it on both paths, so the re-validation now runs an actual curl command against the submit URL.

Closes #468