### PR TITLE
Add return value for `tag_hook()` in `build.lua`

### DIFF
--- a/build.lua
+++ b/build.lua
@@ -95,7 +95,7 @@ function update_tag(file,content,tagname,tagdate)
 end
 
 function tag_hook(tagname)
-  os.execute('git commit -a -m "Step release tag"')
+  return os.execute('git commit -a -m "Step release tag"')
 end
 
 -- Auto-generate a .1 file from the help


### PR DESCRIPTION
This fixes the always non-zero exit code of running `l3build tag <tag>` in this repo.

Lua functions have no default return value.