### PR TITLE
Add `\REGRESSIONTESTFILEDATE` to hold l3build version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ this project uses date-based 'snapshot' version identifiers.
 
 ### Added
 
-- `\REGRESSIONTESTVERSION`, version of `l3build` (issue \#456)
+- `\REGRESSIONTESTFILEDATE`, version of `l3build` (issue \#456)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Added
+
+- `\REGRESSIONTESTVERSION`, version of `l3build` (issue \#456)
+
 ### Changed
 
 - `\SHOWFILE` now logs the first line of file content on new line (issue \#430)

--- a/build.lua
+++ b/build.lua
@@ -70,6 +70,9 @@ function update_tag(file,content,tagname,tagdate)
     content = string.gsub(content,
       "\n%% \\date{Released " .. iso .. "}\n",
       "\n%% \\date{Released " .. tagname .. "}\n")
+    content = string.gsub(content,
+      "\n\\def\\REGRESSIONTESTVERSION{" .. iso .. "}\n",
+      "\n\\def\\REGRESSIONTESTVERSION{" .. tagname .. "}\n")
     return string.gsub(content, "NEXT_RELEASE_DATE", tagname)
   elseif string.match(file, "%.md$") then
     if string.match(file,"CHANGELOG.md") then

--- a/build.lua
+++ b/build.lua
@@ -71,8 +71,8 @@ function update_tag(file,content,tagname,tagdate)
       "\n%% \\date{Released " .. iso .. "}\n",
       "\n%% \\date{Released " .. tagname .. "}\n")
     content = string.gsub(content,
-      "\n\\def\\REGRESSIONTESTVERSION{" .. iso .. "}\n",
-      "\n\\def\\REGRESSIONTESTVERSION{" .. tagname .. "}\n")
+      "\n\\def\\REGRESSIONTESTFILEDATE{" .. iso .. "}\n",
+      "\n\\def\\REGRESSIONTESTFILEDATE{" .. tagname .. "}\n")
     return string.gsub(content, "NEXT_RELEASE_DATE", tagname)
   elseif string.match(file, "%.md$") then
     if string.match(file,"CHANGELOG.md") then

--- a/l3build.dtx
+++ b/l3build.dtx
@@ -992,7 +992,6 @@
 % Once the |regression-test.tex| is loaded, you can access the version of
 % \pkg{l3build} in the ISO date format \meta{year}-\meta{month}-\meta{day}
 % through |\REGRESSIONTESTFILEDATE|.
-% The current version of \pkg{l3build} is \REGRESSIONTESTVERSION.
 %
 % Any commands that write content to the |.log| file that should be ignored can be surrounded by |\OMIT| \dots\ |\TIMO|.
 % At the appropriate location in the document where the |.log| comparisons should start (say, after |\begin{document}|), the test suite must contain the |\START| macro.
@@ -2271,9 +2270,9 @@
 %
 % \subsection{Version}
 %
-% \begin{macro}{\REGRESSIONTESTVERSION}
+% \begin{macro}{\REGRESSIONTESTFILEDATE}
 %    \begin{macrocode}
-\def\REGRESSIONTESTVERSION{2026-09-01}
+\def\REGRESSIONTESTFILEDATE{2026-09-01}
 % \end{macro}
 %
 % \subsection{Preliminaries}

--- a/l3build.dtx
+++ b/l3build.dtx
@@ -989,6 +989,11 @@
 %
 % \subsection{Metadata and structural commands}
 %
+% Once the |regression-test.tex| is loaded, you can access the version of
+% \pkg{l3build} in the ISO date format \meta{year}-\meta{month}-\meta{day}
+% through |\REGRESSIONTESTFILEDATE|.
+% The current version of \pkg{l3build} is \REGRESSIONTESTVERSION.
+%
 % Any commands that write content to the |.log| file that should be ignored can be surrounded by |\OMIT| \dots\ |\TIMO|.
 % At the appropriate location in the document where the |.log| comparisons should start (say, after |\begin{document}|), the test suite must contain the |\START| macro.
 %
@@ -2263,6 +2268,13 @@
 %    \begin{macrocode}
 %<*package>
 %    \end{macrocode}
+%
+% \subsection{Version}
+%
+% \begin{macro}{\REGRESSIONTESTVERSION}
+%    \begin{macrocode}
+\def\REGRESSIONTESTVERSION{2026-09-01}
+% \end{macro}
 %
 % \subsection{Preliminaries}
 %


### PR DESCRIPTION
Suggestions on a better macro name is very welcome.

- The current `\REGRESSIONTESTFILEDATE` is a bit long, but the naming clash possibility is largely reduced.
- <s>Maybe the suffix `(FILE)DATE` is better than `VERSION`?</s>
- All-caps vs CamelCase (`\RegressionTestFileDate`)?

Closes #456.