### PR TITLE
Clean up debugging target help

### DIFF
--- a/l3build-stdmain.lua
+++ b/l3build-stdmain.lua
@@ -74,7 +74,7 @@ target_list =
       {
         bundle_target = true,
         desc = "Runs all automated tests",
-        func = check,help="FOO"
+        func = check
       },
     clean =
       {


### PR DESCRIPTION
Remove debugging `help="FOO"` set for `check` target.

Introduced in 2e00f4b (Support additional help for custom targets, 2026-09-01).

Need a Changelog entry?